### PR TITLE
Add GitHub Action to auto-reset staging branch

### DIFF
--- a/.github/workflows/reset-staging.yml
+++ b/.github/workflows/reset-staging.yml
@@ -1,0 +1,36 @@
+name: Reset Staging to Main
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  reset-staging:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+      
+      - name: Reset staging branch to main
+        run: |
+          # Fetch all branches
+          git fetch origin
+          
+          # Checkout staging branch
+          git checkout staging || git checkout -b staging origin/staging
+          
+          # Reset staging to match main
+          git reset --hard origin/main
+          
+          # Force push to update remote staging
+          git push origin staging --force

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,3 +88,8 @@ node test/index.js schedulingLogic.test.js  # Run specific test file
 - All dates are normalized to midnight UTC for consistency
 - Thread-based signup state is maintained in memory (not persisted)
 - Deploy Discord commands before first run or after command changes
+
+## CI/CD Workflows
+
+### Staging Reset Action
+The repository includes a GitHub Action (`.github/workflows/reset-staging.yml`) that automatically resets the `staging` branch to match `main` whenever code is pushed to the main branch. This ensures staging always reflects the latest production code.


### PR DESCRIPTION
Create workflow that automatically resets staging branch to match main whenever changes are pushed to main. This ensures staging always reflects the latest production code.

- Add reset-staging.yml workflow
- Triggers on push to main branch
- Force resets staging to origin/main
- Update CLAUDE.md with CI/CD documentation

🤖 Generated with [Claude Code](https://claude.ai/code)