### PR TITLE
feat: add debug functionality and improve user help messages

### DIFF
--- a/lib/discord/index.js
+++ b/lib/discord/index.js
@@ -867,7 +867,7 @@ function createClient() {
       try {
         // Outer try for intent detection + handling
         const intentSystemMessage =
-          "You are an assistant classifying user intent in a Discord message where the bot was mentioned. Possible intents are 'sign_up', 'view_schedule', 'cancel_talk', 'query_talks', 'zoom_link', 'schedule_for_others', or 'other'.\n- Classify as 'sign_up' ONLY if the user explicitly asks to sign up, volunteer, present, or talk.\n- Classify as 'view_schedule' ONLY if the user explicitly asks to see the schedule, upcoming talks, or who is speaking.\n- Classify as 'cancel_talk' ONLY if the user explicitly asks to cancel, withdraw, or back out of their scheduled talk.\n- Classify as 'query_talks' ONLY if the user is asking about past talks, previous topics, or if specific topics have been covered before.\n- Classify as 'zoom_link' ONLY if the user is asking for a zoom link, meeting link, presentation link, meeting URL, or any variation of requesting a link/URL for meetings/presentations.\n- Classify as 'schedule_for_others' ONLY if the user explicitly asks to schedule someone else, book someone else, or sign up another person for a talk.\n- Otherwise, classify as 'other'. This includes simple replies, acknowledgements, questions not related to the above, or unclear requests.\nRespond with ONLY the intent name ('sign_up', 'view_schedule', 'cancel_talk', 'query_talks', 'zoom_link', 'schedule_for_others', 'other')."
+          "You are an assistant classifying user intent in a Discord message where the bot was mentioned. Possible intents are 'sign_up', 'view_schedule', 'cancel_talk', 'query_talks', 'zoom_link', 'schedule_for_others', 'debug', or 'other'.\n- Classify as 'sign_up' ONLY if the user explicitly asks to sign up, volunteer, present, or talk.\n- Classify as 'view_schedule' ONLY if the user explicitly asks to see the schedule, upcoming talks, or who is speaking.\n- Classify as 'cancel_talk' ONLY if the user explicitly asks to cancel, withdraw, or back out of their scheduled talk.\n- Classify as 'query_talks' ONLY if the user is asking about past talks, previous topics, or if specific topics have been covered before.\n- Classify as 'zoom_link' ONLY if the user is asking for a zoom link, meeting link, presentation link, meeting URL, or any variation of requesting a link/URL for meetings/presentations.\n- Classify as 'schedule_for_others' ONLY if the user explicitly asks to schedule someone else, book someone else, or sign up another person for a talk.\n- Classify as 'debug' ONLY if the user asks for debug info, debug logs, debugging, troubleshooting, or wants to see how the bot processes messages.\n- Otherwise, classify as 'other'. This includes simple replies, acknowledgements, questions not related to the above, or unclear requests.\nRespond with ONLY the intent name ('sign_up', 'view_schedule', 'cancel_talk', 'query_talks', 'zoom_link', 'schedule_for_others', 'debug', 'other')."
 
         console.log(`Sending to LLM: "${userMessageContent}"`)
         const intentResponse = await completion({
@@ -1290,17 +1290,110 @@ function createClient() {
             }
           }
         }
+        // --- Handle 'debug' Intent ---
+        else if (detectedIntent === 'debug') {
+          console.log('Debug intent detected.')
+          try {
+            // Collect debug information
+            const debugInfo = {
+              originalMessage: message.content,
+              trimmedContent: trimmedContent,
+              userMessageContent: userMessageContent,
+              detectedIntent: detectedIntent,
+              userId: message.author.id,
+              username: message.author.username,
+              channelId: message.channel.id,
+              channelType: message.channel.type,
+              isThread: message.channel.isThread(),
+              guildId: message.guildId,
+              timestamp: new Date().toISOString()
+            }
+
+            // Check if user has any active signup threads
+            const activeSignupThreads = Object.entries(activeSignups)
+              .filter(([threadId, signup]) => signup.userId === message.author.id)
+              .map(([threadId, signup]) => ({
+                threadId,
+                state: signup.state,
+                topic: signup.topic || 'not set',
+                lastUpdated: signup.lastUpdated ? new Date(signup.lastUpdated).toISOString() : 'unknown'
+              }))
+
+            const debugMessage = `🔍 **Debug Information**
+
+**Message Processing:**
+• Original message: \`${debugInfo.originalMessage}\`
+• Cleaned content sent to LLM: \`${debugInfo.userMessageContent}\`
+• Detected intent: \`${debugInfo.detectedIntent}\`
+
+**User Context:**
+• User ID: \`${debugInfo.userId}\`
+• Username: \`${debugInfo.username}\`
+• Channel ID: \`${debugInfo.channelId}\`
+• Is thread: \`${debugInfo.isThread}\`
+• Guild ID: \`${debugInfo.guildId}\`
+
+**Active Signups:**
+${activeSignupThreads.length > 0 
+  ? activeSignupThreads.map(thread => 
+      `• Thread \`${thread.threadId}\`: ${thread.state} (topic: "${thread.topic}", updated: ${thread.lastUpdated})`
+    ).join('\n')
+  : '• No active signup threads for this user'
+}
+
+**Next Steps:**
+Based on the detected intent \`${debugInfo.detectedIntent}\`, the bot would:
+${detectedIntent === 'sign_up' ? '✅ Create a new speaker signup thread' :
+  detectedIntent === 'view_schedule' ? '✅ Display the upcoming speaker schedule' :
+  detectedIntent === 'cancel_talk' ? '✅ Cancel your scheduled talk (if any)' :
+  detectedIntent === 'query_talks' ? '✅ Search past talk history' :
+  detectedIntent === 'zoom_link' ? '✅ Provide the meeting link in a private thread' :
+  detectedIntent === 'schedule_for_others' ? '✅ Start the process to schedule someone else' :
+  '❓ Provide help with available commands'}
+
+**Timestamp:** \`${debugInfo.timestamp}\``
+
+            await message.reply(debugMessage)
+          } catch (error) {
+            console.error('Error generating debug information:', error)
+            try {
+              await message.reply(
+                '🔍 Debug mode activated, but I encountered an error generating the debug information. Check the console logs for details.'
+              )
+            } catch (replyError) {
+              console.error('Failed to send debug error reply:', replyError)
+            }
+          }
+        }
         // --- Handle 'other' or Unrecognized Intent ---
         else {
           // Handles 'other' or any unrecognized intent from LLM
           console.log(
             `LLM intent classified as '${detectedIntent}'. No specific action taken.`,
           )
-          // Send a generic help message if intent is 'other' or unclear
+          // Send a keyword-focused help message if intent is 'other' or unclear
           try {
-            await message.reply(
-              "How can I help? You can ask me to 'sign up', 'schedule someone else', 'view schedule', 'cancel talk', ask about past talks, or get the zoom link!",
-            )
+            const keywordsMessage = `I'm not sure what you're asking for. Here are the keywords I understand:
+
+**📝 Speaking & Scheduling:**
+• \`sign up\` - Volunteer to give a presentation
+• \`schedule someone else\` - Book someone else to speak
+
+**📅 Schedule Management:**
+• \`view schedule\` - See upcoming talks
+• \`cancel talk\` - Cancel your scheduled presentation
+
+**🔍 Talk History:**
+• \`query talks\` or \`past talks\` - Search previous presentations
+
+**🔗 Meeting Info:**
+• \`zoom link\` - Get the meeting link
+
+**🔍 Troubleshooting:**
+• \`debug\` - Show detailed processing information
+
+Try mentioning me with one of these keywords!`
+            await message.reply(keywordsMessage)
           } catch (e) {
             console.error(e)
           }


### PR DESCRIPTION
# Relates to

N/A
<!-- No specific issue linked - this is a feature enhancement -->

# Risks

**Low Risk**
- New debug functionality is isolated and only triggered by explicit user request
- No changes to existing functionality or data handling
- Debug output is informational only and doesn't modify any state

# Background

## What does this PR do?

This PR adds a new `debug` intent classification and handler to the Discord bot, providing developers and users with detailed information about how the bot processes messages. The changes include:

1. **New Debug Intent**: Added 'debug' as a recognized intent in the LLM classification system
2. **Debug Handler**: Implemented a comprehensive debug information display that shows:
   - Original message and cleaned content sent to LLM
   - Detected intent and user context (ID, username, channel info)
   - Active signup threads for the user
   - What action the bot would take based on the detected intent
3. **Enhanced Help Message**: Improved the fallback help message with better structured keyword guidance using emojis and clear categorization

## What kind of change is this?

**Features** (non-breaking change which adds functionality)
- Adds new debug functionality for troubleshooting
- Improves user experience with better help messages

## Why are we doing this? Any context or related work?

This debug functionality was added to help with troubleshooting and understanding how the bot processes user messages. As the bot handles various intents and maintains state across different Discord interactions, having visibility into the message processing pipeline is valuable for:

- Developers debugging issues with intent classification
- Users understanding why their messages might not be interpreted as expected
- Troubleshooting signup thread state and user context issues

# Documentation changes needed?

**My changes require a change to the project documentation.**

The new debug command should be documented for users and developers. Consider updating:
- User-facing documentation to mention the `debug` keyword for troubleshooting
- Developer documentation to explain the debug output format and what information is provided

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

1. **Review the diff in `lib/discord/index.js`** - Focus on:
   - The updated `intentSystemMessage` with the new 'debug' intent
   - The new debug handler implementation (lines ~1293-1385)
   - The enhanced help message for the 'other' intent

2. **Test the debug functionality** by mentioning the bot with "debug" keywords

## Detailed testing steps

### Debug Intent Testing
- In a Discord channel where the bot is present, mention the bot with debug-related keywords:
  - `@bot debug`
  - `@bot show me debug info`
  - `@bot debugging`
  - `@bot troubleshooting`
- Verify that the bot responds with detailed debug information including:
  - Original and cleaned message content
  - Detected intent
  - User context (ID, username, channel info)
  - Active signup threads (if any)
  - Expected next steps

### Enhanced Help Message Testing
- Mention the bot with unclear or unrelated messages:
  - `@bot hello`
  - `@bot random text`
  - `@bot what can you do?`
- Verify that the bot responds with the improved help message showing:
  - Categorized keywords with emojis
  - Clear action descriptions
  - Well-formatted structure

### Regression Testing
- Test existing functionality to ensure no breaking changes:
  - `@bot sign up` should still work for speaker signup
  - `@bot view schedule` should still show the schedule
  - `@bot cancel talk` should still work for cancellation
  - Other existing intents should remain unaffected
