### PR TITLE
Implement Proactive messages

### DIFF
--- a/.ttmp.yaml
+++ b/.ttmp.yaml
@@ -1,0 +1,6 @@
+root: ttmp
+defaults:
+    owners: []
+    intent: ""
+filenamePrefixPolicy: ""
+vocabulary: ttmp/vocabulary.yaml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,7 @@ Examples:
 ## Proactive Messaging
 - **Architecture**: Docker cron (`dcron`) triggers localhost HTTP endpoints (`/internal/proactive/*`) that run jobs using the existing Discord client. Jobs are in `lib/proactive/jobs/` (talk reminders, weekly announcements).
 - **Jobs**: `lib/proactive/jobs/talkReminders.js` sends T-1 day and day-of reminders via DM (with thread fallback). `lib/proactive/jobs/weeklyAnnouncement.js` posts weekly schedule to configured channel. Both jobs are idempotent (track sent timestamps in `ScheduledSpeaker.reminders`).
-- **Channel Configuration**: Use `/set-proactive-channel` Discord command to configure the announcements channel. Configuration is stored in MongoDB (`GuildSettings` model) for runtime updates without container restarts. Falls back to `PROACTIVE_ANNOUNCEMENTS_CHANNEL_ID` env var for backward compatibility.
+- **Channel Configuration**: Use `/set-proactive-channel` Discord command to configure the announcements channel. Configuration is stored in MongoDB (`GuildSettings` model) for runtime updates without container restarts.
 - **Security**: Internal endpoints secured by `middleware/loopback-only.js` (allows loopback IPs, optional `X-Cron-Secret` header). Tests: `test/middleware/loopback-only.test.js` verifies IPv4/IPv6 loopback, rejects non-loopback without secret, allows non-loopback with valid secret.
 - **Testing**: Unit tests in `test/lib/proactive/jobs/` verify job logic, idempotency, date normalization, and fallback behavior. Endpoint tests in `test/api/proactive-internal.test.js` verify security and job invocation. Use `bin/test-proactive.js` for REPL-based testing without Discord (creates test talks, runs jobs, verifies results).
 - **Docker**: `Dockerfile` installs `dcron`; `docker-entrypoint.sh` starts cron alongside Node; `crontab` schedules jobs (daily reminders at 16:00 UTC, weekly announcements Mondays at 15:00 UTC).
@@ -70,6 +70,6 @@ Examples:
 
 ## Security & Configuration
 - Never commit secrets. Use `.env` (see `.env.example`). Required keys live in `config/index.js` (e.g., `DISCORD_TOKEN`, `DISCORD_CLIENT_ID`, `DISCORD_GUILD_ID`, `OPENROUTER_API_KEY`, `MONGO_URI`).
-- **Proactive messaging config**: Optional env vars `PROACTIVE_REMINDERS_ENABLED`, `PROACTIVE_WEEKLY_ENABLED`, `PROACTIVE_ANNOUNCEMENTS_CHANNEL_ID` (deprecated - use `/set-proactive-channel` command instead), `CRON_SECRET`. See `config/index.js` for defaults. Channel configuration is stored in MongoDB via `/set-proactive-channel` command, with env var fallback for backward compatibility.
+- **Proactive messaging config**: Optional env vars `PROACTIVE_REMINDERS_ENABLED`, `PROACTIVE_WEEKLY_ENABLED`, `CRON_SECRET`. See `config/index.js` for defaults. Channel configuration is stored in MongoDB via `/set-proactive-channel` command.
 - Validate configs at startup and prefer mocking in tests.
 - **Internal endpoints**: Routes under `/internal/proactive/*` are secured with loopback-only middleware (`middleware/loopback-only.js`). Tests verify security in `test/middleware/loopback-only.test.js` and `test/api/proactive-internal.test.js`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Project Structure & Module Organization
 - `index.js` starts the Discord bot and HTTP server; `server.js` configures Express routes and errors.
-- `lib/` contains core logic: `discord/` (bot, commands, deploy), `mongo/` (db), `llm/`, `schedulingLogic.js`, `talkHistory.js`.
+- `lib/` contains core logic: `discord/` (bot, commands, deploy), `mongo/` (db), `llm/`, `schedulingLogic.js`, `talkHistory.js`, `proactive/` (proactive messaging jobs).
 - `api/` holds route handlers; `middleware/` includes auth and related middleware.
 - `models/` defines Mongoose schemas.
 - `config/` loads environment from `.env` and exports typed config.
@@ -29,8 +29,9 @@ Examples:
 ## Testing Guidelines
 - Frameworks: Tape + Supertest + mongodb-memory-server.
 - Test files end with `.test.js` under `test/` (subfolders allowed).
-- Aim to cover routes, middleware, Mongo helpers, and Discord command logic with unit/integration tests.
+- Aim to cover routes, middleware, Mongo helpers, Discord command logic, and proactive messaging jobs with unit/integration tests.
 - Cleanups run via `test/helpers/cleanup.js`; avoid relying on external services in tests.
+- **Proactive messaging tests**: See `test/lib/proactive/jobs/`, `test/api/proactive-internal.test.js`, and `test/middleware/loopback-only.test.js`. Tests verify job logic, idempotency, security middleware, and endpoint behavior. Use `bin/test-proactive.js` for REPL-based testing without Discord.
 
 ## Interactive Testing With `bin/aiia-chat`
 - Use the REPL script to simulate Discord conversations locally without the real bot.
@@ -40,6 +41,14 @@ Examples:
 - Switch simulated users with `/as @username`, move between threads with `/switch <parent-or-thread>`, and exit cleanly using `/quit`.
 - When finished, close the REPL (`/quit`) or kill the tmux session: `tmux kill-session -t aiia`.
 
+## Proactive Messaging
+- **Architecture**: Docker cron (`dcron`) triggers localhost HTTP endpoints (`/internal/proactive/*`) that run jobs using the existing Discord client. Jobs are in `lib/proactive/jobs/` (talk reminders, weekly announcements).
+- **Jobs**: `lib/proactive/jobs/talkReminders.js` sends T-1 day and day-of reminders via DM (with thread fallback). `lib/proactive/jobs/weeklyAnnouncement.js` posts weekly schedule to configured channel. Both jobs are idempotent (track sent timestamps in `ScheduledSpeaker.reminders`).
+- **Channel Configuration**: Use `/set-proactive-channel` Discord command to configure the announcements channel. Configuration is stored in MongoDB (`GuildSettings` model) for runtime updates without container restarts. Falls back to `PROACTIVE_ANNOUNCEMENTS_CHANNEL_ID` env var for backward compatibility.
+- **Security**: Internal endpoints secured by `middleware/loopback-only.js` (allows loopback IPs, optional `X-Cron-Secret` header). Tests: `test/middleware/loopback-only.test.js` verifies IPv4/IPv6 loopback, rejects non-loopback without secret, allows non-loopback with valid secret.
+- **Testing**: Unit tests in `test/lib/proactive/jobs/` verify job logic, idempotency, date normalization, and fallback behavior. Endpoint tests in `test/api/proactive-internal.test.js` verify security and job invocation. Use `bin/test-proactive.js` for REPL-based testing without Discord (creates test talks, runs jobs, verifies results).
+- **Docker**: `Dockerfile` installs `dcron`; `docker-entrypoint.sh` starts cron alongside Node; `crontab` schedules jobs (daily reminders at 16:00 UTC, weekly announcements Mondays at 15:00 UTC).
+
 ## Commit & Pull Request Guidelines
 - Commits: short, imperative subject; reference issues/PRs when relevant (e.g., "Update help message (#23)").
 - PRs must include: concise description, linked issues, test coverage notes, local run steps, and screenshots/logs for Discord flows when applicable.
@@ -47,4 +56,6 @@ Examples:
 
 ## Security & Configuration
 - Never commit secrets. Use `.env` (see `.env.example`). Required keys live in `config/index.js` (e.g., `DISCORD_TOKEN`, `DISCORD_CLIENT_ID`, `DISCORD_GUILD_ID`, `OPENROUTER_API_KEY`, `MONGO_URI`).
+- **Proactive messaging config**: Optional env vars `PROACTIVE_REMINDERS_ENABLED`, `PROACTIVE_WEEKLY_ENABLED`, `PROACTIVE_ANNOUNCEMENTS_CHANNEL_ID` (deprecated - use `/set-proactive-channel` command instead), `CRON_SECRET`. See `config/index.js` for defaults. Channel configuration is stored in MongoDB via `/set-proactive-channel` command, with env var fallback for backward compatibility.
 - Validate configs at startup and prefer mocking in tests.
+- **Internal endpoints**: Routes under `/internal/proactive/*` are secured with loopback-only middleware (`middleware/loopback-only.js`). Tests verify security in `test/middleware/loopback-only.test.js` and `test/api/proactive-internal.test.js`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@
 - `config/` loads environment from `.env` and exports typed config.
 - `test/` contains Tape tests (`**/*.test.js`), plus helpers and mocks.
 - `docs/` holds additional documentation; `Dockerfile` builds a runnable image.
+- `ttmp/` contains structured documentation managed by docmgr (ticket workspaces, design docs, implementation diaries).
 
 ## Build, Test, and Development Commands
 - `npm start` — Deploys Discord commands then runs the app (`index.js`).
@@ -53,6 +54,19 @@ Examples:
 - Commits: short, imperative subject; reference issues/PRs when relevant (e.g., "Update help message (#23)").
 - PRs must include: concise description, linked issues, test coverage notes, local run steps, and screenshots/logs for Discord flows when applicable.
 - Ensure `npm test` and `npm run lint` pass; if commands change, update README and `package.json` scripts.
+
+## Documentation Management (docmgr)
+- **Purpose**: Structured documentation in `ttmp/` organized by tickets with metadata, bidirectional code-to-doc linking, and searchability.
+- **Workflow**: Use docmgr commands to create tickets, add documents, relate files, and update changelogs. Write document content in markdown with frontmatter metadata.
+- **Common commands**:
+  - `docmgr ticket create-ticket` - Create new ticket workspace
+  - `docmgr doc add --ticket TICKET --doc-type TYPE --title "Title"` - Add document
+  - `docmgr doc relate --doc PATH --file-note "/abs/path:Note"` - Link code files to docs
+  - `docmgr changelog update --ticket TICKET --entry "Entry"` - Update changelog
+  - `docmgr help how-to-use` - Full usage guide
+- **Document types**: `design-doc`, `reference`, `playbook`, `tutorial`, `code-review`, etc.
+- **Implementation diaries**: Use `reference` doc type for step-by-step implementation narratives. Follow diary format guidelines in `ttmp/_guidelines/reference.md`.
+- **File relationships**: Always use absolute paths in `--file-note` for code-to-doc linking.
 
 ## Security & Configuration
 - Never commit secrets. Use `.env` (see `.env.example`). Required keys live in `config/index.js` (e.g., `DISCORD_TOKEN`, `DISCORD_CLIENT_ID`, `DISCORD_GUILD_ID`, `OPENROUTER_API_KEY`, `MONGO_URI`).

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,11 +7,21 @@ COPY package*.json ./
 # Install only production dependencies
 RUN npm ci --omit=dev
 
+# Install dcron for scheduled jobs
+RUN apk add --no-cache dcron curl
+
 # Copy application code
 COPY . .
 
 # Run the build script (deploys Discord commands)
 RUN npm run build
+
+# Copy crontab and entrypoint script
+COPY docker-entrypoint.sh /usr/local/bin/
+COPY crontab /etc/crontabs/root
+
+# Make entrypoint executable
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
 # Set environment variables
 ENV NODE_ENV=production
@@ -20,5 +30,6 @@ ENV PORT=3000
 # Expose the port the app runs on
 EXPOSE ${PORT}
 
-# Start the application
+# Use entrypoint to start both cron and node
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 CMD [ "node", "index.js" ] 

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,9 @@ RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 # Set environment variables
 ENV NODE_ENV=production
 ENV PORT=3000
+# Enable proactive messaging by default
+ENV PROACTIVE_REMINDERS_ENABLED=true
+ENV PROACTIVE_WEEKLY_ENABLED=true
 
 # Expose the port the app runs on
 EXPOSE ${PORT}

--- a/README.md
+++ b/README.md
@@ -78,8 +78,6 @@ This is a Discord bot designed to facilitate scheduling and potentially other AI
     # Proactive messaging (optional)
     PROACTIVE_REMINDERS_ENABLED=true
     PROACTIVE_WEEKLY_ENABLED=true
-    # PROACTIVE_ANNOUNCEMENTS_CHANNEL_ID is deprecated - use /set-proactive-channel command instead
-    # PROACTIVE_ANNOUNCEMENTS_CHANNEL_ID=your_channel_id_here  # Fallback only
     CRON_SECRET=optional_secret_for_multi_instance_deployments
     ```
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,11 @@ This is a Discord bot designed to facilitate scheduling and potentially other AI
 ├── package.json        # Project dependencies and scripts
 ├── package-lock.json   # Exact dependency versions
 ├── server.js           # Web server setup (Express)
-└── test/               # Automated tests
+├── test/               # Automated tests
+└── ttmp/               # Structured documentation managed by docmgr
+    ├── _templates/     # Document templates
+    ├── _guidelines/     # Writing guidelines
+    └── YYYY/MM/DD/     # Ticket workspaces organized by date
 ```
 
 ## Getting Started
@@ -145,6 +149,54 @@ To verify proactive messaging manually:
 3. Verify DMs sent and reminder timestamps updated in MongoDB
 4. Test idempotency by running the job again (should send 0 reminders)
 
+## Documentation Management (docmgr)
+
+This project uses [docmgr](https://github.com/dguttman/docmgr) to manage structured documentation in the `ttmp/` directory. Documentation is organized into ticket workspaces, each containing design docs, reference materials, playbooks, and implementation diaries.
+
+### Common docmgr Commands
+
+- **Create a ticket workspace:**
+  ```bash
+  docmgr ticket create-ticket --ticket TICKET-ID --title "Ticket Title" --topics topic1,topic2
+  ```
+
+- **Add a document to a ticket:**
+  ```bash
+  docmgr doc add --ticket TICKET-ID --doc-type design-doc --title "Design Document Title"
+  ```
+
+- **Relate files to a document:**
+  ```bash
+  docmgr doc relate --doc ttmp/.../reference/01-diary.md --file-note "/abs/path/to/file.js:Why this file matters"
+  ```
+
+- **Update changelog:**
+  ```bash
+  docmgr changelog update --ticket TICKET-ID --entry "What changed" --file-note "/path/to/file.js:Reason"
+  ```
+
+- **List tickets:**
+  ```bash
+  docmgr ticket tickets
+  ```
+
+- **Get help:**
+  ```bash
+  docmgr help how-to-use
+  ```
+
+### Documentation Structure
+
+Each ticket workspace (`ttmp/YYYY/MM/DD/TICKET-ID--slug/`) contains:
+- `index.md` - Ticket overview and entry point
+- `tasks.md` - Task list
+- `changelog.md` - History of changes
+- `design-doc/` - Design documents and architecture notes
+- `reference/` - Implementation diaries, API contracts, quick reference
+- `playbook/` - Operational procedures and testing guides
+
+Documentation uses frontmatter metadata for searchability and bidirectional code-to-doc linking.
+
 ## Contributing
 
-Please refer to the documentation in the `docs/` directory for contribution guidelines, specifications, and tutorials. 
+Please refer to the documentation in the `docs/` directory for contribution guidelines, specifications, and tutorials. For ticket-based work, use docmgr to create and manage documentation workspaces. 

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ To verify proactive messaging manually:
 
 ## Documentation Management (docmgr)
 
-This project uses [docmgr](https://github.com/dguttman/docmgr) to manage structured documentation in the `ttmp/` directory. Documentation is organized into ticket workspaces, each containing design docs, reference materials, playbooks, and implementation diaries.
+This project sometimes uses [docmgr](https://github.com/go-go-golems/docmgr) to manage structured documentation in the `ttmp/` directory. Documentation is organized into ticket workspaces, each containing design docs, reference materials, playbooks, and implementation diaries.
 
 ### Common docmgr Commands
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,13 @@ This is a Discord bot designed to facilitate scheduling and potentially other AI
 *   **Discord Integration:** Interacts with users through Discord commands.
 *   **LLM Capabilities:** Uses external LLM services (currently configured for OpenRouter) for tasks like processing natural language.
 *   **Scheduling Logic:** Contains logic for scheduling events or speakers (details likely found in `lib/schedulingLogic.js` and `models/scheduledSpeaker.js`).
+*   **Proactive Messaging:** Automatically sends talk reminders (T-1 day and day-of) via DM with thread fallback, and posts weekly schedule announcements to a configured channel. Runs via Docker cron triggering internal HTTP endpoints. Channel configuration via `/set-proactive-channel` Discord command (stored in MongoDB).
 *   **MongoDB Persistence:** Stores scheduling information and potentially other data in a MongoDB database.
 *   **Web Server:** Includes a basic web server (likely for health checks or simple API endpoints).
+
+## Discord Commands
+
+*   `/set-proactive-channel` - Configure the channel for weekly proactive announcements. Stores configuration in MongoDB for runtime updates without container restarts. Requires "Send Messages" permission in the target channel.
 
 ## Project Structure
 
@@ -65,7 +70,13 @@ This is a Discord bot designed to facilitate scheduling and potentially other AI
     GUILD_ID=your_discord_guild_id
     ZOOM_LINK=https://zoom.us/j/yourmeetingid
     ZOOM_PASSWORD=yourpassword
-    # Add any other required variables from config/index.js
+    
+    # Proactive messaging (optional)
+    PROACTIVE_REMINDERS_ENABLED=true
+    PROACTIVE_WEEKLY_ENABLED=true
+    # PROACTIVE_ANNOUNCEMENTS_CHANNEL_ID is deprecated - use /set-proactive-channel command instead
+    # PROACTIVE_ANNOUNCEMENTS_CHANNEL_ID=your_channel_id_here  # Fallback only
+    CRON_SECRET=optional_secret_for_multi_instance_deployments
     ```
 
 ### Running the Bot
@@ -86,6 +97,8 @@ This is a Discord bot designed to facilitate scheduling and potentially other AI
     docker build -t ai-in-action-bot .
     ```
 
+    The Docker image includes `dcron` for scheduled proactive messaging jobs. The entrypoint script (`docker-entrypoint.sh`) starts both cron and Node.js processes.
+
 2.  **Run the Docker container:**
 
     You need to provide the necessary environment variables when running the container. Create a `.env` file as described in the Installation section.
@@ -99,7 +112,15 @@ This is a Discord bot designed to facilitate scheduling and potentially other AI
     *   `-p 3000:3000`: Maps port 3000 on your host to port 3000 in the container.
     *   `--name aiia-bot-instance`: Assigns a name to the container for easier management.
 
-    The bot should now be running inside the Docker container.
+    The bot should now be running inside the Docker container. Both the Discord bot and cron daemon will be active.
+
+3.  **Proactive Messaging Schedule:**
+
+    When `PROACTIVE_REMINDERS_ENABLED=true` and `PROACTIVE_WEEKLY_ENABLED=true` are set, cron jobs run automatically:
+    - **Talk reminders**: Daily at 16:00 UTC (sends T-1 day and day-of reminders)
+    - **Weekly announcements**: Mondays at 15:00 UTC (posts upcoming schedule)
+
+    To verify cron is running: `docker exec aiia-bot-instance ps aux | grep crond`
 
 ## Testing
 
@@ -108,6 +129,21 @@ Run the test suite:
 ```bash
 npm test
 ```
+
+### Testing Proactive Messaging
+
+Proactive messaging functionality is tested through multiple test suites:
+
+- **Unit tests** (`test/lib/proactive/jobs/`): Test job logic, idempotency, date normalization, and fallback behavior. See `test/lib/proactive/jobs/talkReminders.test.js` (tests T-1/day-of reminder selection, idempotency, disabled flag, DM failure fallback) and `test/lib/proactive/jobs/weeklyAnnouncement.test.js` (tests weekly announcement formatting with/without talks, CTA display).
+- **Security tests** (`test/middleware/loopback-only.test.js`): Verify internal endpoint security (allows loopback IPv4/IPv6, rejects non-loopback without secret, allows non-loopback with valid secret).
+- **Endpoint tests** (`test/api/proactive-internal.test.js`): Verify internal endpoints call job functions and enforce security requirements.
+- **REPL testing** (`bin/test-proactive.js`): Test proactive messaging without Discord using the chat simulation client. Run with `npm run test-proactive` or `node bin/test-proactive.js`. Creates test talks, runs jobs, verifies results, and cleans up automatically.
+
+To verify proactive messaging manually:
+1. Create test talks in MongoDB (one for tomorrow, one for today)
+2. Trigger endpoints: `curl -X POST http://127.0.0.1:3000/internal/proactive/check-reminders`
+3. Verify DMs sent and reminder timestamps updated in MongoDB
+4. Test idempotency by running the job again (should send 0 reminders)
 
 ## Contributing
 

--- a/api/proactive-internal.js
+++ b/api/proactive-internal.js
@@ -2,6 +2,8 @@ const express = require('express')
 const router = express.Router()
 const autoCatch = require('../lib/auto-catch')
 const loopbackOnly = require('../middleware/loopback-only')
+const proactive = require('../lib/proactive')
+const discordClient = require('../lib/discord')
 
 // Apply loopback-only security to all routes in this router
 router.use(loopbackOnly)
@@ -14,24 +16,8 @@ router.use(loopbackOnly)
 router.post(
   '/check-reminders',
   autoCatch(async (req, res) => {
-    const startTime = Date.now()
-
-    // TODO: Phase 2 - Call actual job function
-    // const result = await runTalkRemindersJob()
-
-    // Placeholder response for now
-    const duration = Date.now() - startTime
-    res.json({
-      job: 'check-reminders',
-      status: 'success',
-      duration,
-      reminders: {
-        tminus1Sent: 0,
-        dayOfSent: 0,
-        errors: [],
-      },
-      timestamp: new Date().toISOString(),
-    })
+    const result = await proactive.runTalkReminders(discordClient)
+    res.json(result)
   }),
 )
 
@@ -43,23 +29,8 @@ router.post(
 router.post(
   '/weekly-announcement',
   autoCatch(async (req, res) => {
-    const startTime = Date.now()
-
-    // TODO: Phase 2 - Call actual job function
-    // const result = await runWeeklyAnnouncementJob()
-
-    // Placeholder response for now
-    const duration = Date.now() - startTime
-    res.json({
-      job: 'weekly-announcement',
-      status: 'success',
-      duration,
-      announcement: {
-        posted: false,
-        error: null,
-      },
-      timestamp: new Date().toISOString(),
-    })
+    const result = await proactive.runWeeklyAnnouncement(discordClient)
+    res.json(result)
   }),
 )
 

--- a/api/proactive-internal.js
+++ b/api/proactive-internal.js
@@ -1,0 +1,66 @@
+const express = require('express')
+const router = express.Router()
+const autoCatch = require('../lib/auto-catch')
+const loopbackOnly = require('../middleware/loopback-only')
+
+// Apply loopback-only security to all routes in this router
+router.use(loopbackOnly)
+
+/**
+ * POST /internal/proactive/check-reminders
+ * Triggers the talk reminders job.
+ * Returns JSON summary with counts, duration, and errors.
+ */
+router.post(
+  '/check-reminders',
+  autoCatch(async (req, res) => {
+    const startTime = Date.now()
+
+    // TODO: Phase 2 - Call actual job function
+    // const result = await runTalkRemindersJob()
+
+    // Placeholder response for now
+    const duration = Date.now() - startTime
+    res.json({
+      job: 'check-reminders',
+      status: 'success',
+      duration,
+      reminders: {
+        tminus1Sent: 0,
+        dayOfSent: 0,
+        errors: [],
+      },
+      timestamp: new Date().toISOString(),
+    })
+  }),
+)
+
+/**
+ * POST /internal/proactive/weekly-announcement
+ * Triggers the weekly schedule announcement job.
+ * Returns JSON summary with counts, duration, and errors.
+ */
+router.post(
+  '/weekly-announcement',
+  autoCatch(async (req, res) => {
+    const startTime = Date.now()
+
+    // TODO: Phase 2 - Call actual job function
+    // const result = await runWeeklyAnnouncementJob()
+
+    // Placeholder response for now
+    const duration = Date.now() - startTime
+    res.json({
+      job: 'weekly-announcement',
+      status: 'success',
+      duration,
+      announcement: {
+        posted: false,
+        error: null,
+      },
+      timestamp: new Date().toISOString(),
+    })
+  }),
+)
+
+module.exports = router

--- a/bin/test-proactive.js
+++ b/bin/test-proactive.js
@@ -1,0 +1,267 @@
+#!/usr/bin/env node
+/* Test proactive messaging using the chat simulation client (no Discord required). */
+const { ChatClient } = require('../lib/chat-sim/client')
+const { User } = require('../lib/chat-sim/entities')
+const config = require('../config')
+const proactive = require('../lib/proactive')
+
+// Ensure DB connects
+require('../lib/mongo')
+
+// Extend ChatClient to support proactive messaging methods
+class ProactiveTestClient extends ChatClient {
+  constructor(options) {
+    super(options)
+    // Track DMs sent to users
+    this.dmMessages = new Map()
+    // Track channel messages
+    this.channelMessages = new Map()
+
+    // Store original channels Map
+    this._channelsMap = this.channels
+
+    // Add channels.fetch method for Discord.js compatibility
+    this.channels.fetch = async (channelId) => {
+      // Check if it's a known channel
+      let channel = this._channelsMap.get(channelId)
+      if (channel) {
+        // Override send to track messages if not already done
+        if (!channel._sendTracked) {
+          const originalSend = channel.send.bind(channel)
+          channel.send = async (content) => {
+            if (!this.channelMessages.has(channelId)) {
+              this.channelMessages.set(channelId, [])
+            }
+            this.channelMessages.get(channelId).push({
+              content,
+              timestamp: new Date(),
+            })
+            console.log(`\x1b[36m[Channel #${channel.name}]\x1b[0m\n${content}`)
+            return originalSend(content)
+          }
+          channel._sendTracked = true
+        }
+        return channel
+      }
+      // Create a virtual channel for announcements if it doesn't exist
+      const virtualChannel = this.createTextChannel({
+        id: channelId,
+        name: 'announcements',
+      })
+      // Override send to track messages
+      const originalSend = virtualChannel.send.bind(virtualChannel)
+      virtualChannel.send = async (content) => {
+        if (!this.channelMessages.has(channelId)) {
+          this.channelMessages.set(channelId, [])
+        }
+        this.channelMessages.get(channelId).push({
+          content,
+          timestamp: new Date(),
+        })
+        console.log(`\x1b[36m[Channel #announcements]\x1b[0m\n${content}`)
+        return originalSend(content)
+      }
+      virtualChannel._sendTracked = true
+      return virtualChannel
+    }
+  }
+
+  // Override users.fetch to return User with send() method for DMs
+  get users() {
+    const self = this
+    return {
+      fetch: async (userId) => {
+        const user = await super.users.fetch(userId)
+        // Add send method for DMs
+        if (!user.send) {
+          user.send = async (content) => {
+            if (!self.dmMessages.has(userId)) {
+              self.dmMessages.set(userId, [])
+            }
+            self.dmMessages.get(userId).push({
+              content,
+              timestamp: new Date(),
+            })
+            console.log(`\x1b[35m[DM to @${user.username}]\x1b[0m ${content}`)
+            return { id: `dm-${Date.now()}`, content }
+          }
+        }
+        return user
+      },
+    }
+  }
+
+  // Helper to get all DMs sent to a user
+  getDMsForUser(userId) {
+    return this.dmMessages.get(userId) || []
+  }
+
+  // Helper to get all messages sent to a channel
+  getChannelMessages(channelId) {
+    return this.channelMessages.get(channelId) || []
+  }
+
+  // Helper to clear all messages (for testing)
+  clearMessages() {
+    this.dmMessages.clear()
+    this.channelMessages.clear()
+  }
+}
+
+async function main() {
+  const guildId = (config.discord && config.discord.guildId) || 'guild-1'
+  const client = new ProactiveTestClient({
+    guildId,
+    botId: 'bot-1',
+    botName: 'bot',
+  })
+
+  // Create test users
+  const testUser1 = client.ensureUser('alice')
+  const testUser2 = client.ensureUser('bob')
+
+  console.log(
+    '\x1b[1m=== Proactive Messaging Test (No Discord Required)\x1b[0m\n',
+  )
+  console.log(
+    'Using chat simulation client to test proactive messaging jobs.\n',
+  )
+
+  // Set up config for testing
+  const originalRemindersEnabled = config.proactive.remindersEnabled
+  const originalWeeklyEnabled = config.proactive.weeklyEnabled
+  const originalChannelId = config.proactive.announcementsChannelId
+
+  config.proactive.remindersEnabled = true
+  config.proactive.weeklyEnabled = true
+  config.proactive.announcementsChannelId = 'announcements-channel'
+
+  try {
+    // Test 1: Talk Reminders Job
+    console.log('\x1b[1mTest 1: Talk Reminders Job\x1b[0m')
+    console.log('─'.repeat(50))
+
+    const ScheduledSpeaker = require('../models/scheduledSpeaker')
+    const today = new Date()
+    today.setUTCHours(0, 0, 0, 0)
+    const tomorrow = new Date(today)
+    tomorrow.setUTCDate(tomorrow.getUTCDate() + 1)
+
+    // Create test talks
+    console.log('\nCreating test talks...')
+    const talk1 = await ScheduledSpeaker.create({
+      discordUserId: testUser1.id,
+      discordUsername: testUser1.username,
+      topic: 'Test Talk for Tomorrow',
+      scheduledDate: tomorrow,
+      threadId: 'thread-123',
+    })
+    console.log(
+      `✓ Created talk: "${talk1.topic}" scheduled for ${tomorrow.toISOString().split('T')[0]}`,
+    )
+
+    const talk2 = await ScheduledSpeaker.create({
+      discordUserId: testUser2.id,
+      discordUsername: testUser2.username,
+      topic: 'Test Talk for Today',
+      scheduledDate: today,
+      threadId: 'thread-456',
+    })
+    console.log(
+      `✓ Created talk: "${talk2.topic}" scheduled for ${today.toISOString().split('T')[0]}`,
+    )
+
+    // Run reminders job
+    console.log('\nRunning reminders job...')
+    const remindersResult = await proactive.runTalkReminders(client)
+
+    console.log('\nResults:')
+    console.log(JSON.stringify(remindersResult, null, 2))
+
+    // Verify DMs were sent
+    console.log('\n✓ DMs sent:')
+    const aliceDMs = client.getDMsForUser(testUser1.id)
+    const bobDMs = client.getDMsForUser(testUser2.id)
+    console.log(`  - @${testUser1.username}: ${aliceDMs.length} DM(s)`)
+    console.log(`  - @${testUser2.username}: ${bobDMs.length} DM(s)`)
+
+    // Test idempotency
+    console.log('\nTesting idempotency (running job again)...')
+    const remindersResult2 = await proactive.runTalkReminders(client)
+    console.log(
+      `✓ Reminders sent: ${remindersResult2.reminders.tminus1Sent + remindersResult2.reminders.dayOfSent} (should be 0)`,
+    )
+
+    // Test 2: Weekly Announcement Job
+    console.log('\n\n\x1b[1mTest 2: Weekly Announcement Job\x1b[0m')
+    console.log('─'.repeat(50))
+
+    // Create additional upcoming talks
+    const nextWeek = new Date(today)
+    nextWeek.setUTCDate(nextWeek.getUTCDate() + 7)
+    await ScheduledSpeaker.create({
+      discordUserId: testUser1.id,
+      discordUsername: testUser1.username,
+      topic: 'Talk Next Week',
+      scheduledDate: nextWeek,
+    })
+
+    console.log('\nRunning weekly announcement job...')
+    const weeklyResult = await proactive.runWeeklyAnnouncement(client)
+
+    console.log('\nResults:')
+    console.log(JSON.stringify(weeklyResult, null, 2))
+
+    // Verify channel message was sent
+    const channelMessages = client.getChannelMessages('announcements-channel')
+    console.log(`\n✓ Channel messages: ${channelMessages.length}`)
+    if (channelMessages.length > 0) {
+      console.log('\nAnnouncement content:')
+      console.log(channelMessages[0].content)
+    }
+
+    // Test 3: Disabled Features
+    console.log('\n\n\x1b[1mTest 3: Disabled Features\x1b[0m')
+    console.log('─'.repeat(50))
+
+    config.proactive.remindersEnabled = false
+    config.proactive.weeklyEnabled = false
+
+    const disabledReminders = await proactive.runTalkReminders(client)
+    const disabledWeekly = await proactive.runWeeklyAnnouncement(client)
+
+    console.log('\nReminders (disabled):')
+    console.log(JSON.stringify(disabledReminders, null, 2))
+    console.log('\nWeekly (disabled):')
+    console.log(JSON.stringify(disabledWeekly, null, 2))
+
+    // Cleanup
+    console.log('\n\n\x1b[1mCleanup\x1b[0m')
+    console.log('─'.repeat(50))
+    await ScheduledSpeaker.deleteMany({
+      topic: {
+        $in: [
+          'Test Talk for Tomorrow',
+          'Test Talk for Today',
+          'Talk Next Week',
+        ],
+      },
+    })
+    console.log('✓ Test talks deleted')
+
+    console.log('\n\x1b[32m✓ All tests completed!\x1b[0m\n')
+  } catch (error) {
+    console.error('\n\x1b[31m✗ Error:\x1b[0m', error)
+    process.exit(1)
+  } finally {
+    // Restore original config
+    config.proactive.remindersEnabled = originalRemindersEnabled
+    config.proactive.weeklyEnabled = originalWeeklyEnabled
+    config.proactive.announcementsChannelId = originalChannelId
+  }
+}
+
+main().catch((error) => {
+  console.error('Fatal error:', error)
+  process.exit(1)
+})

--- a/bin/test-proactive.js
+++ b/bin/test-proactive.js
@@ -269,7 +269,9 @@ async function main() {
     })
     client.clearMessages()
 
-    console.log('\nRunning weekly announcement job (no talks this week, but talks later)...')
+    console.log(
+      '\nRunning weekly announcement job (no talks this week, but talks later)...',
+    )
     const weeklyResultEmpty = await proactive.runWeeklyAnnouncement(client)
 
     console.log('\nResults:')
@@ -286,7 +288,11 @@ async function main() {
       if (emptyChannelMessages[0].content.includes('volunteer')) {
         console.log('\n✓ CTA for volunteers found!')
       }
-      if (emptyChannelMessages[0].content.includes('No talks scheduled for this week')) {
+      if (
+        emptyChannelMessages[0].content.includes(
+          'No talks scheduled for this week',
+        )
+      ) {
         console.log('\n✓ Correctly identifies no talks THIS WEEK')
       }
     }

--- a/config/index.js
+++ b/config/index.js
@@ -34,6 +34,8 @@ const config = {
   proactive: {
     remindersEnabled: process.env.PROACTIVE_REMINDERS_ENABLED === 'true',
     weeklyEnabled: process.env.PROACTIVE_WEEKLY_ENABLED === 'true',
+    // Deprecated: Use /set-proactive-channel Discord command instead
+    // Kept for backward compatibility - MongoDB lookup takes precedence
     announcementsChannelId: process.env.PROACTIVE_ANNOUNCEMENTS_CHANNEL_ID,
     cronSecret: process.env.CRON_SECRET,
   },

--- a/config/index.js
+++ b/config/index.js
@@ -31,6 +31,12 @@ const config = {
   zoomLink: process.env.ZOOM_LINK,
   zoomPassword: process.env.ZOOM_PASSWORD,
   whitelist: (process.env.WHITELIST || defaults.whitelist.join(',')).split(','),
+  proactive: {
+    remindersEnabled: process.env.PROACTIVE_REMINDERS_ENABLED === 'true',
+    weeklyEnabled: process.env.PROACTIVE_WEEKLY_ENABLED === 'true',
+    announcementsChannelId: process.env.PROACTIVE_ANNOUNCEMENTS_CHANNEL_ID,
+    cronSecret: process.env.CRON_SECRET,
+  },
 }
 
 // Configure logging based on environment

--- a/config/index.js
+++ b/config/index.js
@@ -34,9 +34,6 @@ const config = {
   proactive: {
     remindersEnabled: process.env.PROACTIVE_REMINDERS_ENABLED === 'true',
     weeklyEnabled: process.env.PROACTIVE_WEEKLY_ENABLED === 'true',
-    // Deprecated: Use /set-proactive-channel Discord command instead
-    // Kept for backward compatibility - MongoDB lookup takes precedence
-    announcementsChannelId: process.env.PROACTIVE_ANNOUNCEMENTS_CHANNEL_ID,
     cronSecret: process.env.CRON_SECRET,
   },
 }

--- a/crontab
+++ b/crontab
@@ -1,0 +1,9 @@
+# Proactive messaging cron jobs
+# Format: minute hour day month weekday command
+#
+# T-1 day reminder: run daily at 16:00 UTC
+# Day-of reminder: run daily at 16:00 UTC (same job handles both)
+0 16 * * * curl -fsS -X POST http://127.0.0.1:3000/internal/proactive/check-reminders || true
+
+# Weekly announcement: run every Monday at 15:00 UTC
+0 15 * * 1 curl -fsS -X POST http://127.0.0.1:3000/internal/proactive/weekly-announcement || true

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -e
+
+# Start cron daemon in foreground with log level 2 (errors and warnings)
+# -f flag runs in foreground
+# -l 2 sets log level to 2 (errors and warnings)
+crond -f -l 2 &
+
+# Execute the main command (node index.js)
+exec "$@"

--- a/lib/discord/commands/set-proactive-channel.js
+++ b/lib/discord/commands/set-proactive-channel.js
@@ -1,4 +1,8 @@
-const { SlashCommandBuilder, ChannelType, PermissionFlagsBits } = require('discord.js')
+const {
+  SlashCommandBuilder,
+  ChannelType,
+  PermissionFlagsBits,
+} = require('discord.js')
 const GuildSettings = require('../../../models/guildSettings')
 
 module.exports = {
@@ -40,7 +44,10 @@ module.exports = {
       )
       if (fetchedChannel.permissionsFor) {
         const permissions = fetchedChannel.permissionsFor(botMember)
-        if (!permissions || !permissions.has(PermissionFlagsBits.SendMessages)) {
+        if (
+          !permissions ||
+          !permissions.has(PermissionFlagsBits.SendMessages)
+        ) {
           return interaction.reply({
             content:
               '❌ I do not have permission to send messages in that channel. Please ensure I have "Send Messages" permission.',

--- a/lib/discord/commands/set-proactive-channel.js
+++ b/lib/discord/commands/set-proactive-channel.js
@@ -1,0 +1,84 @@
+const { SlashCommandBuilder, ChannelType, PermissionFlagsBits } = require('discord.js')
+const GuildSettings = require('../../../models/guildSettings')
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('set-proactive-channel')
+    .setDescription('Set the channel for proactive weekly announcements')
+    .addChannelOption((option) =>
+      option
+        .setName('channel')
+        .setDescription('The channel to post weekly announcements')
+        .setRequired(true)
+        .addChannelTypes(ChannelType.GuildText),
+    ),
+  async execute(interaction) {
+    const channel = interaction.options.getChannel('channel')
+    const guildId = interaction.guildId
+    const userId = interaction.user.id
+
+    if (!channel) {
+      return interaction.reply({
+        content: '❌ Please specify a valid text channel.',
+        ephemeral: true,
+      })
+    }
+
+    // Verify channel exists and bot can send messages
+    try {
+      const fetchedChannel = await interaction.client.channels.fetch(channel.id)
+      if (!fetchedChannel) {
+        return interaction.reply({
+          content: '❌ Channel not found.',
+          ephemeral: true,
+        })
+      }
+
+      // Check bot permissions
+      const botMember = await interaction.guild.members.fetch(
+        interaction.client.user.id,
+      )
+      if (fetchedChannel.permissionsFor) {
+        const permissions = fetchedChannel.permissionsFor(botMember)
+        if (!permissions || !permissions.has(PermissionFlagsBits.SendMessages)) {
+          return interaction.reply({
+            content:
+              '❌ I do not have permission to send messages in that channel. Please ensure I have "Send Messages" permission.',
+            ephemeral: true,
+          })
+        }
+      }
+    } catch (error) {
+      console.error('Error validating channel:', error)
+      return interaction.reply({
+        content: '❌ Error validating channel. Please try again.',
+        ephemeral: true,
+      })
+    }
+
+    // Upsert guild settings
+    try {
+      await GuildSettings.findOneAndUpdate(
+        { guildId },
+        {
+          guildId,
+          proactiveAnnouncementsChannelId: channel.id,
+          updatedBy: userId,
+          updatedAt: new Date(),
+        },
+        { upsert: true, new: true },
+      )
+
+      return interaction.reply({
+        content: `✅ Proactive announcements channel set to ${channel}. Weekly announcements will be posted here.`,
+        ephemeral: false,
+      })
+    } catch (error) {
+      console.error('Error saving guild settings:', error)
+      return interaction.reply({
+        content: '❌ Error saving channel configuration. Please try again.',
+        ephemeral: true,
+      })
+    }
+  },
+}

--- a/lib/proactive/getGuildSettings.js
+++ b/lib/proactive/getGuildSettings.js
@@ -1,0 +1,28 @@
+const GuildSettings = require('../../models/guildSettings')
+
+/**
+ * Get guild settings document for a given guild ID.
+ * @param {string} guildId - Discord guild ID
+ * @returns {Promise<Object|null>} - GuildSettings document or null if not found
+ */
+async function getGuildSettings(guildId) {
+  if (!guildId) {
+    return null
+  }
+  return GuildSettings.findOne({ guildId })
+}
+
+/**
+ * Get proactive announcements channel ID for a given guild.
+ * @param {string} guildId - Discord guild ID
+ * @returns {Promise<string|null>} - Channel ID or null if not configured
+ */
+async function getProactiveChannelId(guildId) {
+  const settings = await getGuildSettings(guildId)
+  return settings?.proactiveAnnouncementsChannelId || null
+}
+
+module.exports = {
+  getGuildSettings,
+  getProactiveChannelId,
+}

--- a/lib/proactive/index.js
+++ b/lib/proactive/index.js
@@ -1,0 +1,79 @@
+/**
+ * Proactive messaging module.
+ * Provides job execution functions for proactive messaging features.
+ */
+
+const locks = require('./locks')
+const { runTalkRemindersJob } = require('./jobs/talkReminders')
+const { runWeeklyAnnouncementJob } = require('./jobs/weeklyAnnouncement')
+
+/**
+ * Run a job with locking to prevent overlapping executions.
+ * @param {string} jobName - Name of the job
+ * @param {Function} jobFn - Async function that runs the job
+ * @returns {Promise<Object>} - Job result with status, duration, and job-specific data
+ */
+async function runJobWithLock(jobName, jobFn) {
+  const startTime = Date.now()
+
+  // Try to acquire lock
+  if (!locks.acquireLock(jobName)) {
+    const lockTime = locks.getLockTime(jobName)
+    return {
+      job: jobName,
+      status: 'skipped',
+      reason: 'already_running',
+      lockAcquiredAt: lockTime,
+      duration: Date.now() - startTime,
+      timestamp: new Date().toISOString(),
+    }
+  }
+
+  try {
+    const result = await jobFn()
+    return {
+      job: jobName,
+      status: 'success',
+      duration: Date.now() - startTime,
+      ...result,
+      timestamp: new Date().toISOString(),
+    }
+  } catch (error) {
+    return {
+      job: jobName,
+      status: 'error',
+      error: error.message,
+      duration: Date.now() - startTime,
+      timestamp: new Date().toISOString(),
+    }
+  } finally {
+    locks.releaseLock(jobName)
+  }
+}
+
+/**
+ * Run the talk reminders job.
+ * @param {Object} discordClient - Discord.js client instance
+ * @returns {Promise<Object>} - Job result
+ */
+async function runTalkReminders(discordClient) {
+  return runJobWithLock('talk-reminders', () =>
+    runTalkRemindersJob(discordClient),
+  )
+}
+
+/**
+ * Run the weekly announcement job.
+ * @param {Object} discordClient - Discord.js client instance
+ * @returns {Promise<Object>} - Job result
+ */
+async function runWeeklyAnnouncement(discordClient) {
+  return runJobWithLock('weekly-announcement', () =>
+    runWeeklyAnnouncementJob(discordClient),
+  )
+}
+
+module.exports = {
+  runTalkReminders,
+  runWeeklyAnnouncement,
+}

--- a/lib/proactive/jobs/talkReminders.js
+++ b/lib/proactive/jobs/talkReminders.js
@@ -1,0 +1,179 @@
+/**
+ * Talk reminders job.
+ * Sends reminders to speakers for upcoming talks.
+ */
+
+const ScheduledSpeaker = require('../../../models/scheduledSpeaker')
+const config = require('../../../config')
+
+/**
+ * Normalize a date to midnight UTC for comparison.
+ * @param {Date} date - Date to normalize
+ * @returns {Date} - Date normalized to midnight UTC
+ */
+function normalizeToMidnightUTC(date) {
+  const d = new Date(date)
+  return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()))
+}
+
+/**
+ * Get today's date normalized to midnight UTC.
+ * @returns {Date} - Today at midnight UTC
+ */
+function getTodayUTC() {
+  return normalizeToMidnightUTC(new Date())
+}
+
+/**
+ * Get tomorrow's date normalized to midnight UTC.
+ * @returns {Date} - Tomorrow at midnight UTC
+ */
+function getTomorrowUTC() {
+  const tomorrow = new Date()
+  tomorrow.setUTCDate(tomorrow.getUTCDate() + 1)
+  return normalizeToMidnightUTC(tomorrow)
+}
+
+/**
+ * Send a DM to a user. Falls back to thread if DM fails.
+ * @param {Object} client - Discord.js client
+ * @param {string} userId - Discord user ID
+ * @param {string} threadId - Optional thread ID for fallback
+ * @param {string} content - Message content
+ * @returns {Promise<boolean>} - True if sent successfully, false otherwise
+ */
+async function sendReminder(client, userId, threadId, content) {
+  try {
+    // Try DM first
+    const user = await client.users.fetch(userId)
+    await user.send(content)
+    return true
+  } catch (dmError) {
+    // If DM fails and threadId exists, try thread
+    if (threadId) {
+      try {
+        const thread = await client.channels.fetch(threadId)
+        await thread.send(content)
+        return true
+      } catch (threadError) {
+        console.error(
+          `Failed to send reminder to user ${userId} via DM and thread ${threadId}:`,
+          dmError.message,
+          threadError.message,
+        )
+        return false
+      }
+    }
+    console.error(`Failed to send reminder to user ${userId}:`, dmError.message)
+    return false
+  }
+}
+
+/**
+ * Run the talk reminders job.
+ * @param {Object} client - Discord.js client instance
+ * @returns {Promise<Object>} - Job result with counts and errors
+ */
+async function runTalkRemindersJob(client) {
+  if (!config.proactive.remindersEnabled) {
+    return {
+      reminders: {
+        tminus1Sent: 0,
+        dayOfSent: 0,
+        errors: [],
+      },
+      skipped: true,
+      reason: 'disabled',
+    }
+  }
+
+  const today = getTodayUTC()
+  const tomorrow = getTomorrowUTC()
+  const errors = []
+  let tminus1Sent = 0
+  let dayOfSent = 0
+
+  try {
+    // Find talks scheduled for tomorrow that haven't received T-1 reminder
+    const tomorrowTalks = await ScheduledSpeaker.find({
+      scheduledDate: tomorrow,
+      $or: [
+        { 'reminders.sentTminus1At': { $exists: false } },
+        { 'reminders.sentTminus1At': null },
+      ],
+    })
+
+    // Find talks scheduled for today that haven't received day-of reminder
+    const todayTalks = await ScheduledSpeaker.find({
+      scheduledDate: today,
+      $or: [
+        { 'reminders.sentDayOfAt': { $exists: false } },
+        { 'reminders.sentDayOfAt': null },
+      ],
+    })
+
+    // Send T-1 reminders
+    for (const talk of tomorrowTalks) {
+      const content = `Hi ${talk.discordUsername}! This is a reminder that you're scheduled to speak tomorrow (${talk.scheduledDate.toISOString().split('T')[0]}) about "${talk.topic}". Looking forward to your talk!`
+      const sent = await sendReminder(
+        client,
+        talk.discordUserId,
+        talk.threadId,
+        content,
+      )
+
+      if (sent) {
+        talk.reminders = talk.reminders || {}
+        talk.reminders.sentTminus1At = new Date()
+        await talk.save()
+        tminus1Sent++
+      } else {
+        errors.push({
+          type: 'tminus1',
+          talkId: talk._id,
+          userId: talk.discordUserId,
+          error: 'Failed to send reminder',
+        })
+      }
+    }
+
+    // Send day-of reminders
+    for (const talk of todayTalks) {
+      const content = `Hi ${talk.discordUsername}! This is a reminder that you're speaking today (${talk.scheduledDate.toISOString().split('T')[0]}) about "${talk.topic}". See you soon!`
+      const sent = await sendReminder(
+        client,
+        talk.discordUserId,
+        talk.threadId,
+        content,
+      )
+
+      if (sent) {
+        talk.reminders = talk.reminders || {}
+        talk.reminders.sentDayOfAt = new Date()
+        await talk.save()
+        dayOfSent++
+      } else {
+        errors.push({
+          type: 'dayOf',
+          talkId: talk._id,
+          userId: talk.discordUserId,
+          error: 'Failed to send reminder',
+        })
+      }
+    }
+
+    return {
+      reminders: {
+        tminus1Sent,
+        dayOfSent,
+        errors,
+      },
+    }
+  } catch (error) {
+    throw new Error(`Talk reminders job failed: ${error.message}`)
+  }
+}
+
+module.exports = {
+  runTalkRemindersJob,
+}

--- a/lib/proactive/jobs/weeklyAnnouncement.js
+++ b/lib/proactive/jobs/weeklyAnnouncement.js
@@ -5,6 +5,7 @@
 
 const ScheduledSpeaker = require('../../../models/scheduledSpeaker')
 const config = require('../../../config')
+const { getProactiveChannelId } = require('../getGuildSettings')
 
 /**
  * Normalize a date to midnight UTC for comparison.
@@ -64,11 +65,18 @@ async function runWeeklyAnnouncementJob(client) {
     }
   }
 
-  if (!config.proactive.announcementsChannelId) {
+  // Get channel ID from MongoDB, with fallback to config for backward compatibility
+  const guildId = config.discord.guildId
+  const channelId =
+    (await getProactiveChannelId(guildId)) ||
+    config.proactive.announcementsChannelId
+
+  if (!channelId) {
     return {
       announcement: {
         posted: false,
-        error: 'PROACTIVE_ANNOUNCEMENTS_CHANNEL_ID not configured',
+        error:
+          'Proactive announcements channel not configured. Use `/set-proactive-channel` to configure.',
       },
     }
   }
@@ -87,9 +95,7 @@ async function runWeeklyAnnouncementJob(client) {
 
     const message = formatUpcomingSchedule(thisWeekTalks)
 
-    const channel = await client.channels.fetch(
-      config.proactive.announcementsChannelId,
-    )
+    const channel = await client.channels.fetch(channelId)
     await channel.send(message)
 
     return {

--- a/lib/proactive/jobs/weeklyAnnouncement.js
+++ b/lib/proactive/jobs/weeklyAnnouncement.js
@@ -31,7 +31,12 @@ function getTodayUTC() {
  */
 function formatUpcomingSchedule(talks) {
   if (talks.length === 0) {
-    return 'No upcoming talks scheduled. Want to sign up? Just mention the bot!'
+    return (
+      '## Upcoming Talks\n\n' +
+      'No talks scheduled for this week.\n\n' +
+      '**Want to volunteer to speak?** Just mention the bot and say you want to sign up! ' +
+      "I'll help you pick a date and get you scheduled. We'd love to have you share your knowledge with the community! 🎤"
+    )
   }
 
   let message = '## Upcoming Talks\n\n'

--- a/lib/proactive/jobs/weeklyAnnouncement.js
+++ b/lib/proactive/jobs/weeklyAnnouncement.js
@@ -65,11 +65,9 @@ async function runWeeklyAnnouncementJob(client) {
     }
   }
 
-  // Get channel ID from MongoDB, with fallback to config for backward compatibility
+  // Get channel ID from MongoDB
   const guildId = config.discord.guildId
-  const channelId =
-    (await getProactiveChannelId(guildId)) ||
-    config.proactive.announcementsChannelId
+  const channelId = await getProactiveChannelId(guildId)
 
   if (!channelId) {
     return {

--- a/lib/proactive/jobs/weeklyAnnouncement.js
+++ b/lib/proactive/jobs/weeklyAnnouncement.js
@@ -75,15 +75,17 @@ async function runWeeklyAnnouncementJob(client) {
 
   try {
     const today = getTodayUTC()
-    // Get next 7 talks (next week)
-    const upcomingTalks = await ScheduledSpeaker.find({
-      scheduledDate: { $gte: today },
-      talkCompleted: { $ne: true },
-    })
-      .sort({ scheduledDate: 1 })
-      .limit(7)
+    // Calculate end of this week (7 days from today)
+    const endOfWeek = new Date(today)
+    endOfWeek.setUTCDate(endOfWeek.getUTCDate() + 7)
 
-    const message = formatUpcomingSchedule(upcomingTalks)
+    // Get talks scheduled for this week (next 7 days)
+    const thisWeekTalks = await ScheduledSpeaker.find({
+      scheduledDate: { $gte: today, $lt: endOfWeek },
+      talkCompleted: { $ne: true },
+    }).sort({ scheduledDate: 1 })
+
+    const message = formatUpcomingSchedule(thisWeekTalks)
 
     const channel = await client.channels.fetch(
       config.proactive.announcementsChannelId,
@@ -93,7 +95,7 @@ async function runWeeklyAnnouncementJob(client) {
     return {
       announcement: {
         posted: true,
-        talksCount: upcomingTalks.length,
+        talksCount: thisWeekTalks.length,
         error: null,
       },
     }

--- a/lib/proactive/jobs/weeklyAnnouncement.js
+++ b/lib/proactive/jobs/weeklyAnnouncement.js
@@ -1,0 +1,107 @@
+/**
+ * Weekly announcement job.
+ * Posts upcoming schedule to the configured announcements channel.
+ */
+
+const ScheduledSpeaker = require('../../../models/scheduledSpeaker')
+const config = require('../../../config')
+
+/**
+ * Normalize a date to midnight UTC for comparison.
+ * @param {Date} date - Date to normalize
+ * @returns {Date} - Date normalized to midnight UTC
+ */
+function normalizeToMidnightUTC(date) {
+  const d = new Date(date)
+  return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()))
+}
+
+/**
+ * Get today's date normalized to midnight UTC.
+ * @returns {Date} - Today at midnight UTC
+ */
+function getTodayUTC() {
+  return normalizeToMidnightUTC(new Date())
+}
+
+/**
+ * Format upcoming talks for announcement.
+ * @param {Array} talks - Array of ScheduledSpeaker documents
+ * @returns {string} - Formatted message
+ */
+function formatUpcomingSchedule(talks) {
+  if (talks.length === 0) {
+    return 'No upcoming talks scheduled. Want to sign up? Just mention the bot!'
+  }
+
+  let message = '## Upcoming Talks\n\n'
+  talks.forEach((talk, index) => {
+    const dateStr = talk.scheduledDate.toISOString().split('T')[0]
+    message += `${index + 1}. **${dateStr}** - ${talk.discordUsername}: "${talk.topic}"\n`
+  })
+  return message
+}
+
+/**
+ * Run the weekly announcement job.
+ * @param {Object} client - Discord.js client instance
+ * @returns {Promise<Object>} - Job result
+ */
+async function runWeeklyAnnouncementJob(client) {
+  if (!config.proactive.weeklyEnabled) {
+    return {
+      announcement: {
+        posted: false,
+        error: null,
+      },
+      skipped: true,
+      reason: 'disabled',
+    }
+  }
+
+  if (!config.proactive.announcementsChannelId) {
+    return {
+      announcement: {
+        posted: false,
+        error: 'PROACTIVE_ANNOUNCEMENTS_CHANNEL_ID not configured',
+      },
+    }
+  }
+
+  try {
+    const today = getTodayUTC()
+    // Get next 7 talks (next week)
+    const upcomingTalks = await ScheduledSpeaker.find({
+      scheduledDate: { $gte: today },
+      talkCompleted: { $ne: true },
+    })
+      .sort({ scheduledDate: 1 })
+      .limit(7)
+
+    const message = formatUpcomingSchedule(upcomingTalks)
+
+    const channel = await client.channels.fetch(
+      config.proactive.announcementsChannelId,
+    )
+    await channel.send(message)
+
+    return {
+      announcement: {
+        posted: true,
+        talksCount: upcomingTalks.length,
+        error: null,
+      },
+    }
+  } catch (error) {
+    return {
+      announcement: {
+        posted: false,
+        error: error.message,
+      },
+    }
+  }
+}
+
+module.exports = {
+  runWeeklyAnnouncementJob,
+}

--- a/lib/proactive/locks.js
+++ b/lib/proactive/locks.js
@@ -1,0 +1,55 @@
+/**
+ * Single-process locking utility to prevent overlapping job runs.
+ * Uses in-memory locks keyed by job name.
+ *
+ * For multi-instance deployments, this should be replaced with
+ * a distributed lock (e.g., MongoDB-based).
+ */
+
+const locks = new Map()
+
+/**
+ * Acquire a lock for a job. Returns true if lock was acquired, false if already locked.
+ * @param {string} jobName - Name of the job to lock
+ * @returns {boolean} - True if lock acquired, false if already locked
+ */
+function acquireLock(jobName) {
+  if (locks.has(jobName)) {
+    return false
+  }
+  locks.set(jobName, Date.now())
+  return true
+}
+
+/**
+ * Release a lock for a job.
+ * @param {string} jobName - Name of the job to unlock
+ */
+function releaseLock(jobName) {
+  locks.delete(jobName)
+}
+
+/**
+ * Check if a job is currently locked.
+ * @param {string} jobName - Name of the job to check
+ * @returns {boolean} - True if locked, false if not locked
+ */
+function isLocked(jobName) {
+  return locks.has(jobName)
+}
+
+/**
+ * Get the timestamp when a lock was acquired.
+ * @param {string} jobName - Name of the job
+ * @returns {number|null} - Timestamp or null if not locked
+ */
+function getLockTime(jobName) {
+  return locks.get(jobName) || null
+}
+
+module.exports = {
+  acquireLock,
+  releaseLock,
+  isLocked,
+  getLockTime,
+}

--- a/middleware/loopback-only.js
+++ b/middleware/loopback-only.js
@@ -1,0 +1,38 @@
+const config = require('../config')
+
+/**
+ * Middleware that only allows requests from localhost (loopback).
+ * Optionally validates X-Cron-Secret header if CRON_SECRET is configured.
+ */
+function loopbackOnlyMiddleware(req, res, next) {
+  const remoteAddress = req.socket.remoteAddress || req.ip
+
+  // Check if request is from loopback (127.0.0.1 or ::1)
+  const isLoopback =
+    remoteAddress === '127.0.0.1' ||
+    remoteAddress === '::1' ||
+    remoteAddress === '::ffff:127.0.0.1' ||
+    remoteAddress?.startsWith('127.0.0.1') ||
+    remoteAddress?.startsWith('::1')
+
+  if (!isLoopback) {
+    // If not loopback, require CRON_SECRET header
+    if (config.proactive.cronSecret) {
+      const providedSecret = req.headers['x-cron-secret']
+      if (providedSecret !== config.proactive.cronSecret) {
+        return res.status(403).json({
+          error: 'Forbidden: Invalid or missing X-Cron-Secret header',
+        })
+      }
+    } else {
+      // No secret configured and not loopback - reject
+      return res.status(403).json({
+        error: 'Forbidden: Internal endpoints only accept loopback connections',
+      })
+    }
+  }
+
+  next()
+}
+
+module.exports = loopbackOnlyMiddleware

--- a/models/guildSettings.js
+++ b/models/guildSettings.js
@@ -1,0 +1,30 @@
+const mongoose = require('mongoose')
+
+const guildSettingsSchema = new mongoose.Schema({
+  guildId: {
+    type: String,
+    required: true,
+    unique: true,
+    index: true,
+  },
+  proactiveAnnouncementsChannelId: {
+    type: String,
+  },
+  updatedAt: {
+    type: Date,
+    default: Date.now,
+  },
+  updatedBy: {
+    type: String,
+  },
+})
+
+// Update updatedAt timestamp on save
+guildSettingsSchema.pre('save', function (next) {
+  this.updatedAt = new Date()
+  next()
+})
+
+const GuildSettings = mongoose.model('GuildSettings', guildSettingsSchema)
+
+module.exports = GuildSettings

--- a/models/scheduledSpeaker.js
+++ b/models/scheduledSpeaker.js
@@ -35,6 +35,14 @@ const scheduledSpeakerSchema = new mongoose.Schema({
   schedulerUsername: {
     type: String,
   },
+  reminders: {
+    sentTminus1At: {
+      type: Date,
+    },
+    sentDayOfAt: {
+      type: Date,
+    },
+  },
 })
 
 const ScheduledSpeaker = mongoose.model(

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "deploy-commands": "node lib/discord/deploy-commands.js",
     "lint": "prettier-eslint --write --no-semi --single-quote \"**/*.js\"",
     "test": "NODE_ENV=test node test/index.js",
-    "chat": "node bin/aiia-chat"
+    "chat": "node bin/aiia-chat",
+    "test-proactive": "node bin/test-proactive.js"
   },
   "keywords": [
     "express",

--- a/server.js
+++ b/server.js
@@ -3,6 +3,7 @@ const config = require('./config')
 const mongoose = require('./lib/mongo')
 const autoCatch = require('./lib/auto-catch')
 const authTestRouter = require('./api/auth-test')
+const proactiveInternalRouter = require('./api/proactive-internal')
 const healthpoint = require('healthpoint')
 const authMiddleware = require('./middleware')
 
@@ -24,6 +25,9 @@ app.get(
 
 // API routes
 app.use('/auth', authMiddleware, authTestRouter)
+
+// Internal proactive messaging routes (localhost-only)
+app.use('/internal/proactive', proactiveInternalRouter)
 
 // Error handling middleware
 app.use((err, req, res, next) => {

--- a/test/api/proactive-internal.test.js
+++ b/test/api/proactive-internal.test.js
@@ -1,0 +1,99 @@
+const test = require('tape')
+const supertest = require('supertest')
+const mongoose = require('../../lib/mongo')
+
+// Import server but don't start it
+const server = require('../../server')
+
+// Mock the proactive module to avoid Discord client dependency
+const proactive = require('../../lib/proactive')
+const originalRunTalkReminders = proactive.runTalkReminders
+const originalRunWeeklyAnnouncement = proactive.runWeeklyAnnouncement
+
+test('proactive internal - check-reminders endpoint - requires loopback', async (t) => {
+  // Temporarily unset CRON_SECRET to test loopback-only behavior
+  const originalSecret = process.env.CRON_SECRET
+  delete process.env.CRON_SECRET
+
+  // Reload config to pick up env change
+  delete require.cache[require.resolve('../../config')]
+
+  const res = await supertest(server)
+    .post('/internal/proactive/check-reminders')
+    .set('X-Forwarded-For', '192.168.1.1')
+    .expect(403)
+
+  t.equal(
+    res.body.error,
+    'Forbidden: Internal endpoints only accept loopback connections',
+  )
+
+  // Restore original secret
+  if (originalSecret) {
+    process.env.CRON_SECRET = originalSecret
+  }
+  delete require.cache[require.resolve('../../config')]
+  t.end()
+})
+
+test('proactive internal - check-reminders endpoint - calls job function', async (t) => {
+  // Mock the job function
+  const mockResult = {
+    job: 'talk-reminders',
+    status: 'success',
+    duration: 10,
+    reminders: {
+      tminus1Sent: 2,
+      dayOfSent: 1,
+      errors: [],
+    },
+    timestamp: new Date().toISOString(),
+  }
+
+  proactive.runTalkReminders = async () => mockResult
+
+  const res = await supertest(server)
+    .post('/internal/proactive/check-reminders')
+    .set('X-Forwarded-For', '127.0.0.1')
+    .expect(200)
+
+  t.equal(res.body.job, 'talk-reminders')
+  t.equal(res.body.status, 'success')
+  t.equal(res.body.reminders.tminus1Sent, 2)
+  t.equal(res.body.reminders.dayOfSent, 1)
+
+  // Restore original function
+  proactive.runTalkReminders = originalRunTalkReminders
+  t.end()
+})
+
+test('proactive internal - weekly-announcement endpoint - calls job function', async (t) => {
+  // Mock the job function
+  const mockResult = {
+    job: 'weekly-announcement',
+    status: 'success',
+    duration: 5,
+    announcement: {
+      posted: true,
+      talksCount: 3,
+      error: null,
+    },
+    timestamp: new Date().toISOString(),
+  }
+
+  proactive.runWeeklyAnnouncement = async () => mockResult
+
+  const res = await supertest(server)
+    .post('/internal/proactive/weekly-announcement')
+    .set('X-Forwarded-For', '127.0.0.1')
+    .expect(200)
+
+  t.equal(res.body.job, 'weekly-announcement')
+  t.equal(res.body.status, 'success')
+  t.equal(res.body.announcement.posted, true)
+  t.equal(res.body.announcement.talksCount, 3)
+
+  // Restore original function
+  proactive.runWeeklyAnnouncement = originalRunWeeklyAnnouncement
+  t.end()
+})

--- a/test/lib/discord/commands/set-proactive-channel.test.js
+++ b/test/lib/discord/commands/set-proactive-channel.test.js
@@ -1,0 +1,186 @@
+const test = require('tape')
+const mongoose = require('../../../../lib/mongo')
+const GuildSettings = require('../../../../models/guildSettings')
+const setProactiveChannelCommand = require('../../../../lib/discord/commands/set-proactive-channel')
+
+// Mock Discord interaction
+function createMockInteraction(options = {}) {
+  const {
+    guildId = 'test-guild-123',
+    userId = 'test-user-456',
+    channelId = 'test-channel-789',
+    channelName = 'announcements',
+    hasPermission = true,
+    channelExists = true,
+  } = options
+
+  const mockChannel = {
+    id: channelId,
+    name: channelName,
+    type: 0, // GuildText
+    permissionsFor: (member) => {
+      return {
+        has: (permission) => hasPermission,
+      }
+    },
+  }
+
+  const mockGuild = {
+    id: guildId,
+    members: {
+      fetch: async (id) => ({
+        id,
+        permissions: {
+          has: () => hasPermission,
+        },
+      }),
+    },
+  }
+
+  const mockClient = {
+    channels: {
+      fetch: async (id) => {
+        if (!channelExists) {
+          throw new Error('Channel not found')
+        }
+        return mockChannel
+      },
+    },
+    user: {
+      id: 'bot-user-id',
+    },
+  }
+
+  return {
+    guildId,
+    user: {
+      id: userId,
+      tag: 'testuser#1234',
+    },
+    guild: mockGuild,
+    client: mockClient,
+    options: {
+      getChannel: (name) => {
+        if (name === 'channel') {
+          return mockChannel
+        }
+        return null
+      },
+    },
+    reply: async (options) => {
+      return {
+        content: options.content,
+        ephemeral: options.ephemeral || false,
+      }
+    },
+  }
+}
+
+test('set-proactive-channel - validates channel and saves to MongoDB', async (t) => {
+  await GuildSettings.deleteMany({})
+
+  const interaction = createMockInteraction({
+    guildId: 'guild-save-test',
+    userId: 'user-save-test',
+    channelId: 'channel-save-test',
+    channelName: 'announcements',
+    hasPermission: true,
+    channelExists: true,
+  })
+
+  const result = await setProactiveChannelCommand.execute(interaction)
+
+  t.ok(result.content.includes('✅'))
+  t.ok(result.content.includes('announcements'))
+  t.equal(result.ephemeral, false)
+
+  // Verify saved in MongoDB
+  const settings = await GuildSettings.findOne({ guildId: 'guild-save-test' })
+  t.ok(settings)
+  t.equal(settings.proactiveAnnouncementsChannelId, 'channel-save-test')
+  t.equal(settings.updatedBy, 'user-save-test')
+  t.ok(settings.updatedAt instanceof Date)
+
+  await GuildSettings.deleteMany({})
+  t.end()
+})
+
+test('set-proactive-channel - handles missing permission', async (t) => {
+  await GuildSettings.deleteMany({})
+
+  const interaction = createMockInteraction({
+    guildId: 'guild-perm-test',
+    hasPermission: false,
+  })
+
+  const result = await setProactiveChannelCommand.execute(interaction)
+
+  t.ok(result.content.includes('❌'))
+  t.ok(result.content.includes('permission'))
+  t.equal(result.ephemeral, true)
+
+  // Verify NOT saved in MongoDB
+  const settings = await GuildSettings.findOne({ guildId: 'guild-perm-test' })
+  t.equal(settings, null)
+
+  await GuildSettings.deleteMany({})
+  t.end()
+})
+
+test('set-proactive-channel - handles channel not found', async (t) => {
+  await GuildSettings.deleteMany({})
+
+  const interaction = createMockInteraction({
+    guildId: 'guild-notfound-test',
+    channelExists: false,
+  })
+
+  const result = await setProactiveChannelCommand.execute(interaction)
+
+  t.ok(result.content.includes('❌'))
+  t.equal(result.ephemeral, true)
+
+  // Verify NOT saved in MongoDB
+  const settings = await GuildSettings.findOne({ guildId: 'guild-notfound-test' })
+  t.equal(settings, null)
+
+  await GuildSettings.deleteMany({})
+  t.end()
+})
+
+test('set-proactive-channel - updates existing guild settings', async (t) => {
+  await GuildSettings.deleteMany({})
+
+  const guildId = 'guild-update-test'
+  const oldChannelId = 'old-channel-123'
+
+  // Create existing settings
+  await GuildSettings.create({
+    guildId,
+    proactiveAnnouncementsChannelId: oldChannelId,
+    updatedBy: 'old-user',
+  })
+
+  const interaction = createMockInteraction({
+    guildId,
+    userId: 'new-user-456',
+    channelId: 'new-channel-789',
+    channelName: 'new-announcements',
+  })
+
+  const result = await setProactiveChannelCommand.execute(interaction)
+
+  t.ok(result.content.includes('✅'))
+  // Channel mention format may vary, just check that update succeeded
+  t.ok(result.content.includes('Proactive announcements channel set'))
+
+  // Verify updated in MongoDB
+  const settings = await GuildSettings.findOne({ guildId })
+  t.ok(settings)
+  t.equal(settings.proactiveAnnouncementsChannelId, 'new-channel-789')
+  t.equal(settings.updatedBy, 'new-user-456')
+  t.notEqual(settings.proactiveAnnouncementsChannelId, oldChannelId)
+
+  await GuildSettings.deleteMany({})
+  t.end()
+})

--- a/test/lib/discord/commands/set-proactive-channel.test.js
+++ b/test/lib/discord/commands/set-proactive-channel.test.js
@@ -141,7 +141,9 @@ test('set-proactive-channel - handles channel not found', async (t) => {
   t.equal(result.ephemeral, true)
 
   // Verify NOT saved in MongoDB
-  const settings = await GuildSettings.findOne({ guildId: 'guild-notfound-test' })
+  const settings = await GuildSettings.findOne({
+    guildId: 'guild-notfound-test',
+  })
   t.equal(settings, null)
 
   await GuildSettings.deleteMany({})

--- a/test/lib/proactive/jobs/talkReminders.test.js
+++ b/test/lib/proactive/jobs/talkReminders.test.js
@@ -1,0 +1,250 @@
+const test = require('tape')
+const mongoose = require('../../../lib/mongo')
+const ScheduledSpeaker = require('../../../models/scheduledSpeaker')
+const {
+  runTalkRemindersJob,
+} = require('../../../lib/proactive/jobs/talkReminders')
+const config = require('../../../config')
+
+// Mock Discord client
+function createMockDiscordClient() {
+  const sentMessages = []
+  const users = new Map()
+  const channels = new Map()
+
+  return {
+    users: {
+      fetch: async (userId) => {
+        if (!users.has(userId)) {
+          users.set(userId, {
+            id: userId,
+            send: async (content) => {
+              sentMessages.push({ type: 'dm', userId, content })
+              return { id: 'msg-1', content }
+            },
+          })
+        }
+        return users.get(userId)
+      },
+    },
+    channels: {
+      fetch: async (channelId) => {
+        if (!channels.has(channelId)) {
+          channels.set(channelId, {
+            id: channelId,
+            send: async (content) => {
+              sentMessages.push({ type: 'thread', channelId, content })
+              return { id: 'msg-1', content }
+            },
+          })
+        }
+        return channels.get(channelId)
+      },
+    },
+    getSentMessages: () => sentMessages,
+    clearSentMessages: () => {
+      sentMessages.length = 0
+    },
+  }
+}
+
+test('talk reminders job - finds talks for tomorrow (T-1)', async (t) => {
+  await ScheduledSpeaker.deleteMany({})
+
+  const client = createMockDiscordClient()
+  const today = new Date()
+  today.setUTCHours(0, 0, 0, 0)
+  const tomorrow = new Date(today)
+  tomorrow.setUTCDate(tomorrow.getUTCDate() + 1)
+
+  // Create a talk scheduled for tomorrow
+  const talk = await ScheduledSpeaker.create({
+    discordUserId: 'user-123',
+    discordUsername: 'testuser',
+    topic: 'Test Topic',
+    scheduledDate: tomorrow,
+    threadId: 'thread-123',
+  })
+
+  // Mock config to enable reminders
+  const originalEnabled = config.proactive.remindersEnabled
+  config.proactive.remindersEnabled = true
+
+  const result = await runTalkRemindersJob(client)
+
+  t.equal(result.reminders.tminus1Sent, 1)
+  t.equal(result.reminders.dayOfSent, 0)
+  t.equal(result.reminders.errors.length, 0)
+
+  // Verify reminder was sent
+  const sentMessages = client.getSentMessages()
+  t.equal(sentMessages.length, 1)
+  t.equal(sentMessages[0].type, 'dm')
+  t.equal(sentMessages[0].userId, 'user-123')
+
+  // Verify reminder timestamp was set
+  const updatedTalk = await ScheduledSpeaker.findById(talk._id)
+  t.ok(updatedTalk.reminders.sentTminus1At)
+  t.ok(!updatedTalk.reminders.sentDayOfAt)
+
+  // Cleanup
+  await ScheduledSpeaker.deleteMany({})
+  config.proactive.remindersEnabled = originalEnabled
+  t.end()
+})
+
+test('talk reminders job - finds talks for today (day-of)', async (t) => {
+  await ScheduledSpeaker.deleteMany({})
+
+  const client = createMockDiscordClient()
+  const today = new Date()
+  today.setUTCHours(0, 0, 0, 0)
+
+  // Create a talk scheduled for today
+  const talk = await ScheduledSpeaker.create({
+    discordUserId: 'user-456',
+    discordUsername: 'testuser2',
+    topic: 'Test Topic 2',
+    scheduledDate: today,
+    threadId: 'thread-456',
+  })
+
+  // Mock config to enable reminders
+  const originalEnabled = config.proactive.remindersEnabled
+  config.proactive.remindersEnabled = true
+
+  const result = await runTalkRemindersJob(client)
+
+  t.equal(result.reminders.tminus1Sent, 0)
+  t.equal(result.reminders.dayOfSent, 1)
+  t.equal(result.reminders.errors.length, 0)
+
+  // Verify reminder was sent
+  const sentMessages = client.getSentMessages()
+  t.equal(sentMessages.length, 1)
+  t.equal(sentMessages[0].type, 'dm')
+  t.equal(sentMessages[0].userId, 'user-456')
+
+  // Verify reminder timestamp was set
+  const updatedTalk = await ScheduledSpeaker.findById(talk._id)
+  t.ok(!updatedTalk.reminders.sentTminus1At)
+  t.ok(updatedTalk.reminders.sentDayOfAt)
+
+  // Cleanup
+  await ScheduledSpeaker.deleteMany({})
+  config.proactive.remindersEnabled = originalEnabled
+  t.end()
+})
+
+test('talk reminders job - idempotency - does not send duplicate reminders', async (t) => {
+  await ScheduledSpeaker.deleteMany({})
+
+  const client = createMockDiscordClient()
+  const today = new Date()
+  today.setUTCHours(0, 0, 0, 0)
+  const tomorrow = new Date(today)
+  tomorrow.setUTCDate(tomorrow.getUTCDate() + 1)
+
+  // Create a talk with reminder already sent
+  const talk = await ScheduledSpeaker.create({
+    discordUserId: 'user-789',
+    discordUsername: 'testuser3',
+    topic: 'Test Topic 3',
+    scheduledDate: tomorrow,
+    threadId: 'thread-789',
+    reminders: {
+      sentTminus1At: new Date(),
+    },
+  })
+
+  // Mock config to enable reminders
+  const originalEnabled = config.proactive.remindersEnabled
+  config.proactive.remindersEnabled = true
+
+  const result = await runTalkRemindersJob(client)
+
+  t.equal(result.reminders.tminus1Sent, 0)
+  t.equal(result.reminders.dayOfSent, 0)
+  t.equal(result.reminders.errors.length, 0)
+
+  // Verify no messages were sent
+  const sentMessages = client.getSentMessages()
+  t.equal(sentMessages.length, 0)
+
+  // Cleanup
+  await ScheduledSpeaker.deleteMany({})
+  config.proactive.remindersEnabled = originalEnabled
+  t.end()
+})
+
+test('talk reminders job - respects disabled flag', async (t) => {
+  await ScheduledSpeaker.deleteMany({})
+
+  const client = createMockDiscordClient()
+
+  // Mock config to disable reminders
+  const originalEnabled = config.proactive.remindersEnabled
+  config.proactive.remindersEnabled = false
+
+  const result = await runTalkRemindersJob(client)
+
+  t.equal(result.skipped, true)
+  t.equal(result.reason, 'disabled')
+  t.equal(result.reminders.tminus1Sent, 0)
+  t.equal(result.reminders.dayOfSent, 0)
+
+  // Cleanup
+  await ScheduledSpeaker.deleteMany({})
+  config.proactive.remindersEnabled = originalEnabled
+  t.end()
+})
+
+test('talk reminders job - falls back to thread if DM fails', async (t) => {
+  await ScheduledSpeaker.deleteMany({})
+
+  const client = createMockDiscordClient()
+  const today = new Date()
+  today.setUTCHours(0, 0, 0, 0)
+
+  // Create a talk scheduled for today
+  const talk = await ScheduledSpeaker.create({
+    discordUserId: 'user-fail',
+    discordUsername: 'testuser4',
+    topic: 'Test Topic 4',
+    scheduledDate: today,
+    threadId: 'thread-fail',
+  })
+
+  // Mock users.fetch to throw error (DM fails)
+  const originalFetch = client.users.fetch
+  client.users.fetch = async () => {
+    throw new Error('DM failed')
+  }
+
+  // Mock config to enable reminders
+  const originalEnabled = config.proactive.remindersEnabled
+  config.proactive.remindersEnabled = true
+
+  const result = await runTalkRemindersJob(client)
+
+  t.equal(result.reminders.dayOfSent, 1)
+  t.equal(result.reminders.errors.length, 0)
+
+  // Verify message was sent to thread
+  const sentMessages = client.getSentMessages()
+  t.equal(sentMessages.length, 1)
+  t.equal(sentMessages[0].type, 'thread')
+  t.equal(sentMessages[0].channelId, 'thread-fail')
+
+  // Verify reminder timestamp was set
+  const updatedTalk = await ScheduledSpeaker.findById(talk._id)
+  t.ok(updatedTalk.reminders.sentDayOfAt)
+
+  // Restore original fetch
+  client.users.fetch = originalFetch
+
+  // Cleanup
+  await ScheduledSpeaker.deleteMany({})
+  config.proactive.remindersEnabled = originalEnabled
+  t.end()
+})

--- a/test/lib/proactive/jobs/weeklyAnnouncement.test.js
+++ b/test/lib/proactive/jobs/weeklyAnnouncement.test.js
@@ -57,10 +57,8 @@ test('weekly announcement - shows CTA when no talks this week but talks exist la
 
   // Mock config
   const originalEnabled = config.proactive.weeklyEnabled
-  const originalChannelId = config.proactive.announcementsChannelId
   const originalGuildId = config.discord.guildId
   config.proactive.weeklyEnabled = true
-  config.proactive.announcementsChannelId = null // Use MongoDB instead
   config.discord.guildId = 'test-guild-123'
 
   // Set up MongoDB channel config
@@ -95,7 +93,6 @@ test('weekly announcement - shows CTA when no talks this week but talks exist la
   await ScheduledSpeaker.deleteMany({})
   await GuildSettings.deleteMany({})
   config.proactive.weeklyEnabled = originalEnabled
-  config.proactive.announcementsChannelId = originalChannelId
   config.discord.guildId = originalGuildId
   t.end()
 })
@@ -120,10 +117,8 @@ test('weekly announcement - shows talks when talks exist this week', async (t) =
 
   // Mock config
   const originalEnabled = config.proactive.weeklyEnabled
-  const originalChannelId = config.proactive.announcementsChannelId
   const originalGuildId = config.discord.guildId
   config.proactive.weeklyEnabled = true
-  config.proactive.announcementsChannelId = null // Use MongoDB instead
   config.discord.guildId = 'test-guild-123'
 
   // Set up MongoDB channel config
@@ -158,7 +153,6 @@ test('weekly announcement - shows talks when talks exist this week', async (t) =
   await ScheduledSpeaker.deleteMany({})
   await GuildSettings.deleteMany({})
   config.proactive.weeklyEnabled = originalEnabled
-  config.proactive.announcementsChannelId = originalChannelId
   config.discord.guildId = originalGuildId
   t.end()
 })
@@ -170,10 +164,8 @@ test('weekly announcement - shows CTA when no talks at all', async (t) => {
 
   // Mock config
   const originalEnabled = config.proactive.weeklyEnabled
-  const originalChannelId = config.proactive.announcementsChannelId
   const originalGuildId = config.discord.guildId
   config.proactive.weeklyEnabled = true
-  config.proactive.announcementsChannelId = null // Use MongoDB instead
   config.discord.guildId = 'test-guild-123'
 
   // Set up MongoDB channel config
@@ -200,40 +192,6 @@ test('weekly announcement - shows CTA when no talks at all', async (t) => {
   await ScheduledSpeaker.deleteMany({})
   await GuildSettings.deleteMany({})
   config.proactive.weeklyEnabled = originalEnabled
-  config.proactive.announcementsChannelId = originalChannelId
-  config.discord.guildId = originalGuildId
-  t.end()
-})
-
-test('weekly announcement - handles missing MongoDB configuration with fallback to config', async (t) => {
-  await ScheduledSpeaker.deleteMany({})
-  await GuildSettings.deleteMany({})
-
-  const client = createMockDiscordClient()
-
-  // Mock config with fallback channel ID
-  const originalEnabled = config.proactive.weeklyEnabled
-  const originalChannelId = config.proactive.announcementsChannelId
-  const originalGuildId = config.discord.guildId
-  config.proactive.weeklyEnabled = true
-  config.proactive.announcementsChannelId = 'fallback-channel-id'
-  config.discord.guildId = 'test-guild-no-mongo'
-
-  // No MongoDB config set - should use fallback
-  const result = await runWeeklyAnnouncementJob(client)
-
-  t.equal(result.announcement.posted, true)
-  t.equal(result.announcement.talksCount, 0)
-
-  // Verify message posted to fallback channel
-  const messages = client.getChannelMessages('fallback-channel-id')
-  t.equal(messages.length, 1)
-
-  // Cleanup
-  await ScheduledSpeaker.deleteMany({})
-  await GuildSettings.deleteMany({})
-  config.proactive.weeklyEnabled = originalEnabled
-  config.proactive.announcementsChannelId = originalChannelId
   config.discord.guildId = originalGuildId
   t.end()
 })
@@ -244,12 +202,10 @@ test('weekly announcement - handles missing configuration', async (t) => {
 
   const client = createMockDiscordClient()
 
-  // Mock config with no channel ID
+  // Mock config
   const originalEnabled = config.proactive.weeklyEnabled
-  const originalChannelId = config.proactive.announcementsChannelId
   const originalGuildId = config.discord.guildId
   config.proactive.weeklyEnabled = true
-  config.proactive.announcementsChannelId = null
   config.discord.guildId = 'test-guild-no-config'
 
   // No MongoDB config and no fallback
@@ -263,7 +219,6 @@ test('weekly announcement - handles missing configuration', async (t) => {
   await ScheduledSpeaker.deleteMany({})
   await GuildSettings.deleteMany({})
   config.proactive.weeklyEnabled = originalEnabled
-  config.proactive.announcementsChannelId = originalChannelId
   config.discord.guildId = originalGuildId
   t.end()
 })

--- a/test/lib/proactive/jobs/weeklyAnnouncement.test.js
+++ b/test/lib/proactive/jobs/weeklyAnnouncement.test.js
@@ -1,0 +1,168 @@
+const test = require('tape')
+const mongoose = require('../../../lib/mongo')
+const ScheduledSpeaker = require('../../../models/scheduledSpeaker')
+const {
+  runWeeklyAnnouncementJob,
+} = require('../../../lib/proactive/jobs/weeklyAnnouncement')
+const config = require('../../../config')
+
+// Mock Discord client
+function createMockDiscordClient() {
+  const channelMessages = []
+  const channels = new Map()
+
+  return {
+    channels: {
+      fetch: async (channelId) => {
+        if (!channels.has(channelId)) {
+          channels.set(channelId, {
+            id: channelId,
+            name: 'announcements',
+            send: async (content) => {
+              channelMessages.push({ channelId, content })
+              return { id: 'msg-1', content }
+            },
+          })
+        }
+        return channels.get(channelId)
+      },
+    },
+    getChannelMessages: (channelId) => {
+      return channelMessages.filter((m) => m.channelId === channelId)
+    },
+    clearChannelMessages: () => {
+      channelMessages.length = 0
+    },
+  }
+}
+
+test('weekly announcement - shows CTA when no talks this week but talks exist later', async (t) => {
+  await ScheduledSpeaker.deleteMany({})
+
+  const client = createMockDiscordClient()
+  const today = new Date()
+  today.setUTCHours(0, 0, 0, 0)
+
+  // Create a talk scheduled for 2 weeks from now (beyond this week)
+  const twoWeeksFromNow = new Date(today)
+  twoWeeksFromNow.setUTCDate(twoWeeksFromNow.getUTCDate() + 14)
+
+  await ScheduledSpeaker.create({
+    discordUserId: 'user-123',
+    discordUsername: 'testuser',
+    topic: 'Talk in Two Weeks',
+    scheduledDate: twoWeeksFromNow,
+  })
+
+  // Mock config
+  const originalEnabled = config.proactive.weeklyEnabled
+  const originalChannelId = config.proactive.announcementsChannelId
+  config.proactive.weeklyEnabled = true
+  config.proactive.announcementsChannelId = 'announcements-channel'
+
+  const result = await runWeeklyAnnouncementJob(client)
+
+  t.equal(result.announcement.posted, true)
+  t.equal(result.announcement.talksCount, 0, 'Should find 0 talks for this week')
+
+  // Verify message contains CTA
+  const messages = client.getChannelMessages('announcements-channel')
+  t.equal(messages.length, 1)
+  t.ok(
+    messages[0].content.includes('Want to volunteer to speak?'),
+    'Message should include CTA',
+  )
+  t.ok(
+    messages[0].content.includes('No talks scheduled for this week'),
+    'Message should indicate no talks this week',
+  )
+
+  // Cleanup
+  await ScheduledSpeaker.deleteMany({})
+  config.proactive.weeklyEnabled = originalEnabled
+  config.proactive.announcementsChannelId = originalChannelId
+  t.end()
+})
+
+test('weekly announcement - shows talks when talks exist this week', async (t) => {
+  await ScheduledSpeaker.deleteMany({})
+
+  const client = createMockDiscordClient()
+  const today = new Date()
+  today.setUTCHours(0, 0, 0, 0)
+
+  // Create a talk scheduled for 3 days from now (within this week)
+  const threeDaysFromNow = new Date(today)
+  threeDaysFromNow.setUTCDate(threeDaysFromNow.getUTCDate() + 3)
+
+  await ScheduledSpeaker.create({
+    discordUserId: 'user-123',
+    discordUsername: 'testuser',
+    topic: 'Talk This Week',
+    scheduledDate: threeDaysFromNow,
+  })
+
+  // Mock config
+  const originalEnabled = config.proactive.weeklyEnabled
+  const originalChannelId = config.proactive.announcementsChannelId
+  config.proactive.weeklyEnabled = true
+  config.proactive.announcementsChannelId = 'announcements-channel'
+
+  const result = await runWeeklyAnnouncementJob(client)
+
+  t.equal(result.announcement.posted, true)
+  t.equal(result.announcement.talksCount, 1, 'Should find 1 talk for this week')
+
+  // Verify message shows talks (not CTA)
+  const messages = client.getChannelMessages('announcements-channel')
+  t.equal(messages.length, 1)
+  t.ok(
+    messages[0].content.includes('Upcoming Talks'),
+    'Message should show upcoming talks',
+  )
+  t.ok(
+    messages[0].content.includes('Talk This Week'),
+    'Message should include talk topic',
+  )
+  t.ok(
+    !messages[0].content.includes('Want to volunteer to speak?'),
+    'Message should NOT include CTA when talks exist',
+  )
+
+  // Cleanup
+  await ScheduledSpeaker.deleteMany({})
+  config.proactive.weeklyEnabled = originalEnabled
+  config.proactive.announcementsChannelId = originalChannelId
+  t.end()
+})
+
+test('weekly announcement - shows CTA when no talks at all', async (t) => {
+  await ScheduledSpeaker.deleteMany({})
+
+  const client = createMockDiscordClient()
+
+  // Mock config
+  const originalEnabled = config.proactive.weeklyEnabled
+  const originalChannelId = config.proactive.announcementsChannelId
+  config.proactive.weeklyEnabled = true
+  config.proactive.announcementsChannelId = 'announcements-channel'
+
+  const result = await runWeeklyAnnouncementJob(client)
+
+  t.equal(result.announcement.posted, true)
+  t.equal(result.announcement.talksCount, 0)
+
+  // Verify message contains CTA
+  const messages = client.getChannelMessages('announcements-channel')
+  t.equal(messages.length, 1)
+  t.ok(
+    messages[0].content.includes('Want to volunteer to speak?'),
+    'Message should include CTA',
+  )
+
+  // Cleanup
+  await ScheduledSpeaker.deleteMany({})
+  config.proactive.weeklyEnabled = originalEnabled
+  config.proactive.announcementsChannelId = originalChannelId
+  t.end()
+})

--- a/test/middleware/loopback-only.test.js
+++ b/test/middleware/loopback-only.test.js
@@ -1,0 +1,100 @@
+const test = require('tape')
+const supertest = require('supertest')
+const express = require('express')
+
+// Create a test router that uses loopback-only middleware
+const loopbackOnly = require('../../middleware/loopback-only')
+
+const app = express()
+app.use(express.json())
+
+// Test endpoint protected by loopback-only middleware
+app.post('/test', loopbackOnly, (req, res) => {
+  res.json({ success: true })
+})
+
+test('loopback-only middleware - allows localhost IPv4', async (t) => {
+  const res = await supertest(app)
+    .post('/test')
+    .set('X-Forwarded-For', '127.0.0.1')
+    .expect(200)
+
+  t.equal(res.body.success, true)
+  t.end()
+})
+
+test('loopback-only middleware - allows localhost IPv6', async (t) => {
+  const res = await supertest(app)
+    .post('/test')
+    .set('X-Forwarded-For', '::1')
+    .expect(200)
+
+  t.equal(res.body.success, true)
+  t.end()
+})
+
+test('loopback-only middleware - rejects non-loopback without secret', async (t) => {
+  // Temporarily unset CRON_SECRET to test loopback-only behavior
+  const originalSecret = process.env.CRON_SECRET
+  delete process.env.CRON_SECRET
+
+  // Reload config to pick up env change
+  delete require.cache[require.resolve('../../config')]
+
+  const res = await supertest(app)
+    .post('/test')
+    .set('X-Forwarded-For', '192.168.1.1')
+    .expect(403)
+
+  t.equal(
+    res.body.error,
+    'Forbidden: Internal endpoints only accept loopback connections',
+  )
+
+  // Restore original secret
+  if (originalSecret) {
+    process.env.CRON_SECRET = originalSecret
+  }
+  delete require.cache[require.resolve('../../config')]
+  t.end()
+})
+
+test('loopback-only middleware - allows non-loopback with valid secret', async (t) => {
+  const testSecret = 'test-secret-123'
+  process.env.CRON_SECRET = testSecret
+
+  // Reload config to pick up env change
+  delete require.cache[require.resolve('../../config')]
+
+  const res = await supertest(app)
+    .post('/test')
+    .set('X-Forwarded-For', '192.168.1.1')
+    .set('X-Cron-Secret', testSecret)
+    .expect(200)
+
+  t.equal(res.body.success, true)
+
+  delete process.env.CRON_SECRET
+  delete require.cache[require.resolve('../../config')]
+  t.end()
+})
+
+test('loopback-only middleware - rejects non-loopback with invalid secret', async (t) => {
+  const testSecret = 'test-secret-123'
+  process.env.CRON_SECRET = testSecret
+
+  // Reload config to pick up env change
+  delete require.cache[require.resolve('../../config')]
+
+  const res = await supertest(app)
+    .post('/test')
+    .set('X-Forwarded-For', '192.168.1.1')
+    .set('X-Cron-Secret', 'wrong-secret')
+    .expect(403)
+
+  t.equal(res.body.error, 'Forbidden: Invalid or missing X-Cron-Secret header')
+
+  delete process.env.CRON_SECRET
+  delete require.cache[require.resolve('../../config')]
+  t.end()
+})

--- a/test/models/guildSettings.test.js
+++ b/test/models/guildSettings.test.js
@@ -1,0 +1,180 @@
+const test = require('tape')
+const mongoose = require('../../lib/mongo')
+const GuildSettings = require('../../models/guildSettings')
+const {
+  getGuildSettings,
+  getProactiveChannelId,
+} = require('../../lib/proactive/getGuildSettings')
+
+test('guildSettings - create and update', async (t) => {
+  await GuildSettings.deleteMany({})
+
+  const guildId = 'guild-123'
+  const channelId = 'channel-456'
+  const userId = 'user-789'
+
+  // Create initial settings
+  const settings = await GuildSettings.create({
+    guildId,
+    proactiveAnnouncementsChannelId: channelId,
+    updatedBy: userId,
+  })
+
+  t.equal(settings.guildId, guildId)
+  t.equal(settings.proactiveAnnouncementsChannelId, channelId)
+  t.equal(settings.updatedBy, userId)
+  t.ok(settings.updatedAt instanceof Date)
+
+  // Update channel ID
+  const newChannelId = 'channel-789'
+  settings.proactiveAnnouncementsChannelId = newChannelId
+  await settings.save()
+
+  const updated = await GuildSettings.findOne({ guildId })
+  t.equal(updated.proactiveAnnouncementsChannelId, newChannelId)
+  t.ok(updated.updatedAt instanceof Date)
+
+  await GuildSettings.deleteMany({})
+  t.end()
+})
+
+test('guildSettings - unique constraint on guildId', async (t) => {
+  await GuildSettings.deleteMany({})
+
+  const guildId = 'guild-unique-test'
+
+  // Create first document
+  await GuildSettings.create({
+    guildId,
+    proactiveAnnouncementsChannelId: 'channel-1',
+  })
+
+  // Try to create duplicate - should fail
+  try {
+    await GuildSettings.create({
+      guildId,
+      proactiveAnnouncementsChannelId: 'channel-2',
+    })
+    t.fail('Should have thrown error for duplicate guildId')
+  } catch (err) {
+    t.ok(
+      err.message.includes('duplicate key') ||
+        err.message.includes('E11000'),
+      'Should throw duplicate key error',
+    )
+  }
+
+  await GuildSettings.deleteMany({})
+  t.end()
+})
+
+test('guildSettings - query by guildId', async (t) => {
+  await GuildSettings.deleteMany({})
+
+  const guildId1 = 'guild-1'
+  const guildId2 = 'guild-2'
+
+  await GuildSettings.create({
+    guildId: guildId1,
+    proactiveAnnouncementsChannelId: 'channel-1',
+  })
+
+  await GuildSettings.create({
+    guildId: guildId2,
+    proactiveAnnouncementsChannelId: 'channel-2',
+  })
+
+  const found1 = await GuildSettings.findOne({ guildId: guildId1 })
+  t.equal(found1.guildId, guildId1)
+  t.equal(found1.proactiveAnnouncementsChannelId, 'channel-1')
+
+  const found2 = await GuildSettings.findOne({ guildId: guildId2 })
+  t.equal(found2.guildId, guildId2)
+  t.equal(found2.proactiveAnnouncementsChannelId, 'channel-2')
+
+  await GuildSettings.deleteMany({})
+  t.end()
+})
+
+test('getGuildSettings - returns settings when found', async (t) => {
+  await GuildSettings.deleteMany({})
+
+  const guildId = 'guild-get-test'
+  const channelId = 'channel-get-test'
+
+  await GuildSettings.create({
+    guildId,
+    proactiveAnnouncementsChannelId: channelId,
+  })
+
+  const settings = await getGuildSettings(guildId)
+  t.ok(settings)
+  t.equal(settings.guildId, guildId)
+  t.equal(settings.proactiveAnnouncementsChannelId, channelId)
+
+  await GuildSettings.deleteMany({})
+  t.end()
+})
+
+test('getGuildSettings - returns null when not found', async (t) => {
+  await GuildSettings.deleteMany({})
+
+  const settings = await getGuildSettings('non-existent-guild')
+  t.equal(settings, null)
+
+  t.end()
+})
+
+test('getGuildSettings - returns null for null/undefined guildId', async (t) => {
+  const settings1 = await getGuildSettings(null)
+  t.equal(settings1, null)
+
+  const settings2 = await getGuildSettings(undefined)
+  t.equal(settings2, null)
+
+  t.end()
+})
+
+test('getProactiveChannelId - returns channel ID when configured', async (t) => {
+  await GuildSettings.deleteMany({})
+
+  const guildId = 'guild-channel-test'
+  const channelId = 'channel-channel-test'
+
+  await GuildSettings.create({
+    guildId,
+    proactiveAnnouncementsChannelId: channelId,
+  })
+
+  const result = await getProactiveChannelId(guildId)
+  t.equal(result, channelId)
+
+  await GuildSettings.deleteMany({})
+  t.end()
+})
+
+test('getProactiveChannelId - returns null when not configured', async (t) => {
+  await GuildSettings.deleteMany({})
+
+  const result = await getProactiveChannelId('non-existent-guild')
+  t.equal(result, null)
+
+  t.end()
+})
+
+test('getProactiveChannelId - returns null when channel ID not set', async (t) => {
+  await GuildSettings.deleteMany({})
+
+  const guildId = 'guild-no-channel'
+
+  await GuildSettings.create({
+    guildId,
+    // proactiveAnnouncementsChannelId not set
+  })
+
+  const result = await getProactiveChannelId(guildId)
+  t.equal(result, null)
+
+  await GuildSettings.deleteMany({})
+  t.end()
+})

--- a/test/models/guildSettings.test.js
+++ b/test/models/guildSettings.test.js
@@ -58,8 +58,7 @@ test('guildSettings - unique constraint on guildId', async (t) => {
     t.fail('Should have thrown error for duplicate guildId')
   } catch (err) {
     t.ok(
-      err.message.includes('duplicate key') ||
-        err.message.includes('E11000'),
+      err.message.includes('duplicate key') || err.message.includes('E11000'),
       'Should throw duplicate key error',
     )
   }

--- a/ttmp/.docmgrignore
+++ b/ttmp/.docmgrignore
@@ -1,0 +1,4 @@
+# Default ignores for docmgr
+.git/
+_templates/
+_guidelines/

--- a/ttmp/2025/12/19/ADD_PROACTIVE_MESSAGES--add-proactive-messages/README.md
+++ b/ttmp/2025/12/19/ADD_PROACTIVE_MESSAGES--add-proactive-messages/README.md
@@ -1,0 +1,21 @@
+# Add Proactive Messages
+
+This is the document workspace for ticket ADD_PROACTIVE_MESSAGES.
+
+## Structure
+
+- **design/**: Design documents and architecture notes
+- **reference/**: Reference documentation and API contracts
+- **playbooks/**: Operational playbooks and procedures
+- **scripts/**: Utility scripts and automation
+- **sources/**: External sources and imported documents
+- **various/**: Scratch or meeting notes, working notes
+- **archive/**: Optional space for deprecated or reference-only artifacts
+
+## Getting Started
+
+Use docmgr commands to manage this workspace:
+
+- Add documents: `docmgr add design-doc "My Design"`
+- Import sources: `docmgr import file path/to/doc.md`
+- Update metadata: `docmgr meta update --field Status --value review`

--- a/ttmp/2025/12/19/ADD_PROACTIVE_MESSAGES--add-proactive-messages/changelog.md
+++ b/ttmp/2025/12/19/ADD_PROACTIVE_MESSAGES--add-proactive-messages/changelog.md
@@ -72,3 +72,8 @@ Step 4: Add unit tests for proactive messaging (commit 1c3f28d)
 
 - /Users/kball/git/ai-in-action-bot/test/ — Added comprehensive test coverage
 
+
+## 2025-12-19
+
+Ticket closed
+

--- a/ttmp/2025/12/19/ADD_PROACTIVE_MESSAGES--add-proactive-messages/changelog.md
+++ b/ttmp/2025/12/19/ADD_PROACTIVE_MESSAGES--add-proactive-messages/changelog.md
@@ -1,0 +1,43 @@
+# Changelog
+
+## 2025-12-19
+
+- Initial workspace created
+
+
+## 2025-12-19 - Created Implementation Plan
+
+Created comprehensive design document outlining the plan for adding proactive messaging capabilities. The plan includes architecture design, implementation phases, use cases (talk reminders, weekly announcements, event notifications), and open questions. Documented integration points with existing Discord client and database schema.
+
+
+## 2025-12-19 - Added Cron Integration Analysis
+
+Added detailed 'Cron Integration Approaches' section explaining three cron-based alternatives: external cron services (GitHub Actions/AWS EventBridge), internal node-cron library, and MongoDB TTL-based scheduling. Includes code examples, architecture diagrams, pros/cons, and comparison table for each approach.
+
+
+## 2025-12-19 - Added Docker Cron Approach
+
+Added detailed Docker cron integration approach (Approach 3) since bot runs in Docker. Includes Dockerfile updates, crontab configuration, entrypoint script, and HTTP endpoint approach. Updated design decisions to recommend Docker cron over polling. Updated comparison table and implementation plan to reflect Docker cron as the recommended approach.
+
+
+## 2025-12-19 - Added cron-driven detailed implementation plan
+
+Added design doc 02-cron-driven-proactive-messaging-detailed-implementation-plan.md with a file-by-file, cron-first implementation plan (Docker dcron + localhost HTTP triggers + job modules + idempotent reminder tracking).
+
+
+## 2025-12-19 - Populated tasks
+
+Converted cron-driven proactive messaging plan into a detailed task list in tasks.md (phases 0-6: config, internal endpoints, jobs, schema, Docker cron, tests, rollout).
+
+
+## 2025-12-19
+
+Step 1: Add internal proactive router with security (commit 547ef56)
+
+### Related Files
+
+- /Users/kball/git/ai-in-action-bot/api/proactive-internal.js — Created internal router
+- /Users/kball/git/ai-in-action-bot/config/index.js — Added proactive config
+- /Users/kball/git/ai-in-action-bot/middleware/loopback-only.js — Created security middleware
+- /Users/kball/git/ai-in-action-bot/server.js — Mounted router
+

--- a/ttmp/2025/12/19/ADD_PROACTIVE_MESSAGES--add-proactive-messages/changelog.md
+++ b/ttmp/2025/12/19/ADD_PROACTIVE_MESSAGES--add-proactive-messages/changelog.md
@@ -41,3 +41,14 @@ Step 1: Add internal proactive router with security (commit 547ef56)
 - /Users/kball/git/ai-in-action-bot/middleware/loopback-only.js — Created security middleware
 - /Users/kball/git/ai-in-action-bot/server.js — Mounted router
 
+
+## 2025-12-19
+
+Step 2: Implement proactive messaging jobs and extend schema (commit ee57c1c)
+
+### Related Files
+
+- /Users/kball/git/ai-in-action-bot/api/proactive-internal.js — Connected to job functions
+- /Users/kball/git/ai-in-action-bot/lib/proactive/ — Created proactive module with jobs and locks
+- /Users/kball/git/ai-in-action-bot/models/scheduledSpeaker.js — Extended schema with reminders
+

--- a/ttmp/2025/12/19/ADD_PROACTIVE_MESSAGES--add-proactive-messages/changelog.md
+++ b/ttmp/2025/12/19/ADD_PROACTIVE_MESSAGES--add-proactive-messages/changelog.md
@@ -63,3 +63,12 @@ Step 3: Add Docker cron integration (commit bb258db)
 - /Users/kball/git/ai-in-action-bot/crontab — Added cron schedule
 - /Users/kball/git/ai-in-action-bot/docker-entrypoint.sh — Created entrypoint script
 
+
+## 2025-12-19
+
+Step 4: Add unit tests for proactive messaging (commit 1c3f28d)
+
+### Related Files
+
+- /Users/kball/git/ai-in-action-bot/test/ — Added comprehensive test coverage
+

--- a/ttmp/2025/12/19/ADD_PROACTIVE_MESSAGES--add-proactive-messages/changelog.md
+++ b/ttmp/2025/12/19/ADD_PROACTIVE_MESSAGES--add-proactive-messages/changelog.md
@@ -52,3 +52,14 @@ Step 2: Implement proactive messaging jobs and extend schema (commit ee57c1c)
 - /Users/kball/git/ai-in-action-bot/lib/proactive/ — Created proactive module with jobs and locks
 - /Users/kball/git/ai-in-action-bot/models/scheduledSpeaker.js — Extended schema with reminders
 
+
+## 2025-12-19
+
+Step 3: Add Docker cron integration (commit bb258db)
+
+### Related Files
+
+- /Users/kball/git/ai-in-action-bot/Dockerfile — Added dcron and entrypoint
+- /Users/kball/git/ai-in-action-bot/crontab — Added cron schedule
+- /Users/kball/git/ai-in-action-bot/docker-entrypoint.sh — Created entrypoint script
+

--- a/ttmp/2025/12/19/ADD_PROACTIVE_MESSAGES--add-proactive-messages/design-doc/01-proactive-messaging-implementation-plan.md
+++ b/ttmp/2025/12/19/ADD_PROACTIVE_MESSAGES--add-proactive-messages/design-doc/01-proactive-messaging-implementation-plan.md
@@ -1,0 +1,1080 @@
+---
+Title: Proactive Messaging Implementation Plan
+Ticket: ADD_PROACTIVE_MESSAGES
+Status: active
+Topics:
+    - discord
+    - bot
+    - scheduling
+DocType: design-doc
+Intent: long-term
+Owners: []
+RelatedFiles:
+    - Path: Dockerfile
+      Note: Will be updated to install dcron and add entrypoint script for running cron alongside Node.js
+    - Path: index.js
+      Note: Application entry point - proactive service will start after Discord client ready
+    - Path: lib/discord/index.js
+      Note: Discord client initialization and event handling - will integrate proactive service
+    - Path: lib/schedulingLogic.js
+      Note: Scheduling functions that will trigger proactive notifications
+    - Path: lib/shared/message-handler.js
+      Note: Current reactive message handling - proactive messages will complement this
+    - Path: models/scheduledSpeaker.js
+      Note: Database model that will be extended with reminder tracking fields
+ExternalSources: []
+Summary: Comprehensive plan for adding proactive messaging capabilities to send unsolicited messages based on events and schedules
+LastUpdated: 2025-12-19T13:11:44.318304-08:00
+---
+
+
+
+# Proactive Messaging Implementation Plan
+
+## Executive Summary
+
+This design proposes adding proactive messaging capabilities to the AI in Action Discord bot, enabling it to send unsolicited messages based on scheduled events, time-based triggers, and system events. Currently, the bot only responds to user messages and slash commands. This enhancement will allow the bot to proactively communicate with users for purposes such as talk reminders, weekly schedule summaries, and other time-based notifications.
+
+The solution introduces a scheduling service using Node.js timers and a message queue system, integrated with the existing Discord client architecture. This will be implemented incrementally, starting with talk reminders and expanding to other proactive messaging use cases.
+
+## Problem Statement
+
+The current bot implementation is purely reactive—it only responds when users interact with it via messages or slash commands. This limitation prevents the bot from:
+
+1. **Sending talk reminders**: Users scheduled to speak may forget about their upcoming talks without proactive reminders
+2. **Weekly schedule announcements**: The community cannot receive automatic weekly summaries of upcoming speakers
+3. **Event-based notifications**: The bot cannot notify users about schedule changes, cancellations, or other important events
+4. **Engagement opportunities**: Missing chances to engage users proactively (e.g., "We haven't had a speaker in a while, want to sign up?")
+
+These limitations reduce the bot's value as an automated community management tool and require manual intervention for time-sensitive communications.
+
+## Proposed Solution
+
+### Architecture Overview
+
+The solution introduces three main components:
+
+1. **Proactive Messaging Service** (`lib/proactive/index.js`): Core service that manages scheduled messages and event-driven notifications
+2. **Message Queue** (`lib/proactive/queue.js`): In-memory queue for pending messages with retry logic
+3. **Scheduler** (`lib/proactive/scheduler.js`): Time-based scheduler using Node.js `setInterval` and date calculations
+
+### Core Components
+
+#### 1. Proactive Messaging Service
+
+A centralized service that:
+- Manages all proactive message types
+- Provides a unified API for sending proactive messages
+- Handles message delivery failures and retries
+- Tracks message state (pending, sent, failed)
+
+**API Design:**
+```javascript
+// lib/proactive/index.js
+async function sendProactiveMessage({
+  channelId,        // Discord channel ID (required)
+  userId,           // Discord user ID (optional, for DMs)
+  content,         // Message content
+  options = {}      // Additional Discord.js message options
+})
+
+async function scheduleMessage({
+  scheduledTime,    // Date when message should be sent
+  channelId,
+  userId,
+  content,
+  options = {}
+})
+```
+
+#### 2. Message Scheduler
+
+A time-based scheduler that:
+- Checks for scheduled messages at regular intervals (e.g., every minute)
+- Processes messages whose scheduled time has passed
+- Handles timezone considerations (using UTC for consistency)
+- Manages recurring schedules (daily, weekly checks)
+
+**Implementation Pattern:**
+```javascript
+// lib/proactive/scheduler.js
+class MessageScheduler {
+  constructor(client, proactiveService) {
+    this.client = client
+    this.proactiveService = proactiveService
+    this.intervalId = null
+  }
+
+  start() {
+    // Check every minute for messages to send
+    this.intervalId = setInterval(() => {
+      this.processScheduledMessages()
+    }, 60 * 1000)
+    
+    // Also check immediately on startup
+    this.processScheduledMessages()
+  }
+
+  async processScheduledMessages() {
+    // Query database or in-memory queue for messages due to be sent
+    // Send messages via proactiveService
+  }
+}
+```
+
+#### 3. Talk Reminder System
+
+Specific implementation for talk reminders:
+- Queries MongoDB for upcoming talks
+- Sends reminders at configurable intervals (e.g., 1 day before, 1 hour before)
+- Tracks which reminders have been sent to avoid duplicates
+
+**Reminder Logic:**
+```javascript
+// lib/proactive/talkReminders.js
+async function checkAndSendTalkReminders(client) {
+  const upcomingTalks = await getUpcomingSchedule(10) // Get next 10 talks
+  const now = new Date()
+  
+  for (const talk of upcomingTalks) {
+    const timeUntilTalk = talk.scheduledDate - now
+    const hoursUntilTalk = timeUntilTalk / (1000 * 60 * 60)
+    
+    // Send 24-hour reminder
+    if (hoursUntilTalk <= 24 && hoursUntilTalk > 23 && !talk.reminder24hSent) {
+      await sendTalkReminder(talk, '24h')
+      await markReminderSent(talk._id, '24h')
+    }
+    
+    // Send 1-hour reminder
+    if (hoursUntilTalk <= 1 && hoursUntilTalk > 0 && !talk.reminder1hSent) {
+      await sendTalkReminder(talk, '1h')
+      await markReminderSent(talk._id, '1h')
+    }
+  }
+}
+```
+
+### Integration Points
+
+#### Discord Client Integration
+
+The proactive messaging service needs access to:
+- Discord client instance (for sending messages)
+- Guild/channel information (for determining where to send messages)
+- User information (for DMs or mentions)
+
+**Integration in `lib/discord/index.js`:**
+```javascript
+const { createProactiveService } = require('../proactive')
+
+function createClient() {
+  const client = new Client({...})
+  
+  // ... existing setup ...
+  
+  client.once(Events.ClientReady, () => {
+    console.log(`Ready! Logged in as ${client.user.tag}`)
+    client.user.setActivity('for speaker sign-ups', { type: 'WATCHING' })
+    
+    // Initialize proactive messaging after client is ready
+    const proactiveService = createProactiveService(client)
+    proactiveService.start()
+  })
+  
+  return client
+}
+```
+
+#### Database Schema Updates
+
+Add reminder tracking fields to `ScheduledSpeaker` model:
+
+```javascript
+// models/scheduledSpeaker.js
+reminder24hSent: {
+  type: Boolean,
+  default: false,
+},
+reminder1hSent: {
+  type: Boolean,
+  default: false,
+},
+reminderSentAt: {
+  type: Date,
+}
+```
+
+### Use Cases
+
+#### 1. Talk Reminders
+
+**24-hour reminder:**
+- Trigger: 24 hours before scheduled talk
+- Recipient: Speaker (via DM or thread)
+- Content: "Reminder: You're scheduled to speak tomorrow on [topic] at [time]"
+
+**1-hour reminder:**
+- Trigger: 1 hour before scheduled talk
+- Recipient: Speaker (via DM or thread)
+- Content: "Reminder: Your talk '[topic]' starts in 1 hour!"
+
+#### 2. Weekly Schedule Announcements
+
+**Weekly summary:**
+- Trigger: Every Monday at 9 AM (configurable)
+- Recipient: Announcement channel
+- Content: "This week's speakers: [list of upcoming talks]"
+
+#### 3. Schedule Change Notifications
+
+**Reschedule notification:**
+- Trigger: When a talk is rescheduled
+- Recipient: Speaker (via DM or thread)
+- Content: "Your talk has been rescheduled to [new date]"
+
+**Cancellation notification:**
+- Trigger: When a talk is cancelled
+- Recipient: Speaker (via DM or thread)
+- Content: "Your talk on [date] has been cancelled"
+
+#### 4. Engagement Prompts
+
+**Low activity prompt:**
+- Trigger: If no talks scheduled for next 2 weeks
+- Recipient: General channel
+- Content: "We're looking for speakers! Interested in presenting?"
+
+## Design Decisions
+
+### 1. Scheduling Mechanism
+
+**Decision**: Use Docker container cron (system cron) with HTTP endpoint triggers.
+
+**Rationale**: 
+- Bot runs in Docker (`node:lts-alpine`), so system cron is readily available
+- Standard Unix cron is reliable and well-understood
+- No external dependencies or additional services needed
+- Precise timing control with standard cron syntax
+- HTTP endpoint approach allows cron to trigger running bot instance
+- Simpler than polling every 60 seconds
+
+**Alternative Considered**: Internal polling with `setInterval` - rejected because cron is more standard and doesn't require continuous polling overhead.
+
+### 2. Message Queue
+
+**Decision**: Start with in-memory queue, migrate to database if needed.
+
+**Rationale**: 
+- Simpler initial implementation
+- Sufficient for low-volume use cases (talk reminders)
+- Can migrate to MongoDB-based queue if persistence becomes important
+
+### 3. Reminder Tracking
+
+**Decision**: Store reminder flags in the `ScheduledSpeaker` model.
+
+**Rationale**:
+- Simple and straightforward
+- Avoids duplicate reminders
+- Easy to query and update
+
+### 4. Message Delivery Method
+
+**Decision**: Prefer threads for talk reminders, channels for announcements.
+
+**Rationale**:
+- Threads provide context and keep conversations organized
+- Channels are better for broadcast messages
+- Can fall back to DMs if thread unavailable
+
+### 5. Error Handling
+
+**Decision**: Log errors and continue processing other messages.
+
+**Rationale**:
+- Failures in one message shouldn't block others
+- Errors can be monitored via logs
+- Can add retry logic later if needed
+
+## Alternatives Considered
+
+### 1. External Cron Service
+
+**Alternative**: Use external cron service (e.g., GitHub Actions, AWS EventBridge) to trigger HTTP endpoints.
+
+**Rejected because**:
+- Adds external dependencies
+- Requires HTTP endpoint management
+- More complex deployment
+- Less control over timing
+
+**What it would look like**: See detailed explanation in "Cron Integration Approaches" section below.
+
+### 2. Database-Driven Scheduling
+
+**Alternative**: Store all scheduled messages in MongoDB and poll database.
+
+**Rejected because**:
+- More complex initial implementation
+- Overkill for current use cases
+- Can migrate to this approach later if needed
+
+### 3. Discord Scheduled Events API
+
+**Alternative**: Use Discord's built-in scheduled events feature.
+
+**Rejected because**:
+- Scheduled events are for calendar events, not messages
+- Doesn't provide the flexibility needed for custom messaging
+- Limited to specific Discord event types
+
+### 4. Message Queue Service (Redis/RabbitMQ)
+
+**Alternative**: Use external message queue service.
+
+**Rejected because**:
+- Adds infrastructure complexity
+- Requires additional service management
+- Overkill for current scale
+- Can adopt later if needed
+
+## Cron Integration Approaches
+
+While cron-based approaches were rejected for the initial implementation, here's what they would look like if adopted:
+
+### Approach 1: External Cron Service (GitHub Actions, AWS EventBridge, etc.)
+
+This approach uses an external service to trigger HTTP endpoints at scheduled intervals.
+
+#### Architecture
+
+```
+External Cron Service (GitHub Actions / AWS EventBridge / Cron-job.org)
+    ↓ (HTTP POST at scheduled times)
+Express HTTP Endpoint (/api/proactive/check-reminders)
+    ↓
+Proactive Messaging Service
+    ↓
+Discord Client (send messages)
+```
+
+#### Implementation
+
+**1. Add HTTP Endpoint to Express Server**
+
+```javascript
+// api/proactive-trigger.js
+const express = require('express')
+const router = express.Router()
+const { checkAndSendTalkReminders } = require('../lib/proactive/talkReminders')
+const discord = require('../lib/discord')
+
+router.post('/check-reminders', async (req, res) => {
+  try {
+    // Verify request is from authorized cron service
+    const cronSecret = req.headers['x-cron-secret']
+    if (cronSecret !== process.env.CRON_SECRET) {
+      return res.status(401).json({ error: 'Unauthorized' })
+    }
+
+    // Get Discord client instance
+    const client = discord // Assuming discord module exports client
+    
+    // Check and send reminders
+    const results = await checkAndSendTalkReminders(client)
+    
+    res.json({ 
+      success: true, 
+      remindersSent: results.length,
+      timestamp: new Date().toISOString()
+    })
+  } catch (error) {
+    console.error('Error processing proactive reminders:', error)
+    res.status(500).json({ error: 'Internal server error' })
+  }
+})
+
+module.exports = router
+```
+
+**2. Register Route in server.js**
+
+```javascript
+// server.js
+const proactiveTriggerRouter = require('./api/proactive-trigger')
+
+// ... existing code ...
+
+app.use('/api/proactive', proactiveTriggerRouter)
+```
+
+**3. GitHub Actions Cron Example**
+
+```yaml
+# .github/workflows/proactive-reminders.yml
+name: Proactive Reminders
+
+on:
+  schedule:
+    # Run every hour
+    - cron: '0 * * * *'
+  workflow_dispatch: # Allow manual trigger
+
+jobs:
+  trigger-reminders:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Reminder Check
+        run: |
+          curl -X POST \
+            -H "Content-Type: application/json" \
+            -H "X-Cron-Secret: ${{ secrets.CRON_SECRET }}" \
+            https://your-bot-domain.com/api/proactive/check-reminders
+```
+
+**4. AWS EventBridge Example**
+
+```json
+{
+  "Rules": [
+    {
+      "Name": "ProactiveRemindersHourly",
+      "ScheduleExpression": "rate(1 hour)",
+      "State": "ENABLED",
+      "Targets": [
+        {
+          "Arn": "arn:aws:lambda:region:account:function:triggerReminders",
+          "Id": "1"
+        }
+      ]
+    }
+  ]
+}
+```
+
+**Pros:**
+- No need to keep process running continuously
+- Can leverage existing infrastructure (GitHub Actions is free for public repos)
+- Easy to monitor and debug (cron service logs)
+- Can scale independently
+
+**Cons:**
+- Requires external service setup and configuration
+- Adds HTTP endpoint that needs security (API keys/secrets)
+- Less precise timing (depends on cron service schedule)
+- Requires bot to be accessible via HTTP (may need reverse proxy/domain)
+
+### Approach 2: Internal Cron Library (node-cron)
+
+This approach uses a Node.js cron library within the bot process.
+
+#### Architecture
+
+```
+Bot Process Startup
+    ↓
+Initialize node-cron scheduler
+    ↓ (runs on schedule)
+Proactive Messaging Service
+    ↓
+Discord Client (send messages)
+```
+
+#### Implementation
+
+**1. Install node-cron**
+
+```bash
+npm install node-cron
+```
+
+**2. Create Cron-Based Scheduler**
+
+```javascript
+// lib/proactive/cronScheduler.js
+const cron = require('node-cron')
+const { checkAndSendTalkReminders } = require('./talkReminders')
+const { sendWeeklyAnnouncement } = require('./weeklyAnnouncements')
+
+class CronScheduler {
+  constructor(client) {
+    this.client = client
+    this.jobs = []
+  }
+
+  start() {
+    // Check for talk reminders every hour
+    const reminderJob = cron.schedule('0 * * * *', async () => {
+      console.log('Running scheduled reminder check...')
+      try {
+        await checkAndSendTalkReminders(this.client)
+      } catch (error) {
+        console.error('Error in scheduled reminder check:', error)
+      }
+    })
+    this.jobs.push(reminderJob)
+
+    // Send weekly announcement every Monday at 9 AM UTC
+    const weeklyJob = cron.schedule('0 9 * * 1', async () => {
+      console.log('Running weekly announcement...')
+      try {
+        await sendWeeklyAnnouncement(this.client)
+      } catch (error) {
+        console.error('Error in weekly announcement:', error)
+      }
+    })
+    this.jobs.push(weeklyJob)
+
+    console.log('Cron scheduler started')
+  }
+
+  stop() {
+    this.jobs.forEach(job => job.stop())
+    console.log('Cron scheduler stopped')
+  }
+}
+
+module.exports = { CronScheduler }
+```
+
+**3. Integrate with Discord Client**
+
+```javascript
+// lib/discord/index.js
+const { CronScheduler } = require('../proactive/cronScheduler')
+
+function createClient() {
+  const client = new Client({...})
+  
+  // ... existing setup ...
+  
+  client.once(Events.ClientReady, () => {
+    console.log(`Ready! Logged in as ${client.user.tag}`)
+    client.user.setActivity('for speaker sign-ups', { type: 'WATCHING' })
+    
+    // Start cron scheduler
+    const cronScheduler = new CronScheduler(client)
+    cronScheduler.start()
+    
+    // Store scheduler for cleanup on shutdown
+    client.cronScheduler = cronScheduler
+  })
+  
+  return client
+}
+```
+
+**4. Handle Graceful Shutdown**
+
+```javascript
+// index.js
+const discord = require('./lib/discord')
+
+// Graceful shutdown
+process.on('SIGTERM', () => {
+  console.log('SIGTERM received, shutting down gracefully...')
+  if (discord.cronScheduler) {
+    discord.cronScheduler.stop()
+  }
+  process.exit(0)
+})
+```
+
+**Pros:**
+- No external dependencies
+- Precise timing control
+- Simple to implement
+- Works entirely within bot process
+
+**Cons:**
+- Requires bot process to run continuously
+- If bot crashes, scheduled tasks are lost until restart
+- Less flexible than external cron (harder to modify schedules without code changes)
+
+### Approach 3: Docker Container Cron (System Cron)
+
+Since the bot runs in a Docker container using `node:lts-alpine`, we can use the system cron daemon directly in the container.
+
+#### Architecture
+
+```
+Docker Container Startup
+    ↓
+Start cron daemon (dcron)
+    ↓ (runs on schedule)
+Shell script executes Node.js script
+    ↓
+HTTP endpoint or direct function call
+    ↓
+Discord Client (send messages)
+```
+
+#### Implementation
+
+**1. Update Dockerfile to Install Cron**
+
+```dockerfile
+FROM node:lts-alpine AS base
+WORKDIR /usr/src/app
+
+# Install dcron (lightweight cron for Alpine)
+RUN apk add --no-cache dcron
+
+# Install dependencies
+COPY package*.json ./
+RUN npm ci --omit=dev
+
+# Copy application code
+COPY . .
+
+# Run the build script (deploys Discord commands)
+RUN npm run build
+
+# Copy cron configuration
+COPY crontab /etc/crontabs/root
+
+# Copy startup script
+COPY docker-entrypoint.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+# Set environment variables
+ENV NODE_ENV=production
+ENV PORT=3000
+
+# Expose the port
+EXPOSE ${PORT}
+
+# Use entrypoint script that starts both cron and Node.js
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+CMD ["node", "index.js"]
+```
+
+**2. Create crontab File**
+
+```bash
+# crontab
+# Check for talk reminders every hour
+0 * * * * /usr/src/app/bin/check-reminders.sh
+
+# Send weekly announcement every Monday at 9 AM UTC
+0 9 * * 1 /usr/src/app/bin/weekly-announcement.sh
+```
+
+**3. Create Shell Scripts for Cron Jobs**
+
+```bash
+#!/bin/sh
+# bin/check-reminders.sh
+
+# Set working directory
+cd /usr/src/app
+
+# Call Node.js script that checks and sends reminders
+node -e "
+const discord = require('./lib/discord');
+const { checkAndSendTalkReminders } = require('./lib/proactive/talkReminders');
+
+discord.once('ready', async () => {
+  try {
+    await checkAndSendTalkReminders(discord);
+    process.exit(0);
+  } catch (error) {
+    console.error('Error in reminder check:', error);
+    process.exit(1);
+  }
+});
+"
+```
+
+**4. Create Docker Entrypoint Script**
+
+```bash
+#!/bin/sh
+# docker-entrypoint.sh
+
+# Start cron daemon in background
+crond -f -l 2 &
+
+# Wait a moment for cron to start
+sleep 1
+
+# Execute the main command (node index.js)
+exec "$@"
+```
+
+**5. Alternative: HTTP Endpoint Approach**
+
+Instead of direct function calls, cron can trigger HTTP endpoints:
+
+```bash
+#!/bin/sh
+# bin/check-reminders.sh
+
+# Call HTTP endpoint (requires bot to be running)
+curl -X POST http://localhost:3000/api/proactive/check-reminders \
+  -H "X-Cron-Secret: ${CRON_SECRET}" \
+  -H "Content-Type: application/json"
+```
+
+**6. Add HTTP Endpoint for Cron Triggers**
+
+```javascript
+// api/proactive-trigger.js
+const express = require('express')
+const router = express.Router()
+const { checkAndSendTalkReminders } = require('../lib/proactive/talkReminders')
+const discord = require('../lib/discord')
+
+router.post('/check-reminders', async (req, res) => {
+  try {
+    // Verify request is from cron (localhost only)
+    if (req.ip !== '127.0.0.1' && req.ip !== '::1') {
+      const cronSecret = req.headers['x-cron-secret']
+      if (cronSecret !== process.env.CRON_SECRET) {
+        return res.status(401).json({ error: 'Unauthorized' })
+      }
+    }
+
+    const results = await checkAndSendTalkReminders(discord)
+    
+    res.json({ 
+      success: true, 
+      remindersSent: results.length,
+      timestamp: new Date().toISOString()
+    })
+  } catch (error) {
+    console.error('Error processing proactive reminders:', error)
+    res.status(500).json({ error: 'Internal server error' })
+  }
+})
+
+module.exports = router
+```
+
+**7. Register Route in server.js**
+
+```javascript
+// server.js
+const proactiveTriggerRouter = require('./api/proactive-trigger')
+
+// ... existing code ...
+
+app.use('/api/proactive', proactiveTriggerRouter)
+```
+
+**Pros:**
+- Uses standard Unix cron (familiar, reliable)
+- No external dependencies
+- Works entirely within container
+- Precise timing control
+- Can use standard cron syntax
+
+**Cons:**
+- Requires Dockerfile changes
+- Need to manage cron daemon lifecycle
+- Shell scripts add complexity
+- Logs go to cron log files (need to configure)
+- If using HTTP approach, requires bot to be running
+
+**Recommended Approach:** Use HTTP endpoint approach so cron jobs can trigger the running bot instance, avoiding the need to start/stop Discord connections.
+
+### Approach 4: Database-Driven Cron (MongoDB TTL + Change Streams)
+
+This approach uses MongoDB's TTL indexes and change streams to trigger actions.
+
+#### Architecture
+
+```
+MongoDB ScheduledMessage Collection
+    ↓ (TTL index expires documents)
+MongoDB Change Stream Listener
+    ↓ (detects expired documents)
+Proactive Messaging Service
+    ↓
+Discord Client (send messages)
+```
+
+#### Implementation
+
+**1. Create Scheduled Message Model**
+
+```javascript
+// models/scheduledMessage.js
+const mongoose = require('mongoose')
+
+const scheduledMessageSchema = new mongoose.Schema({
+  type: {
+    type: String,
+    enum: ['talk_reminder_24h', 'talk_reminder_1h', 'weekly_announcement'],
+    required: true
+  },
+  scheduledFor: {
+    type: Date,
+    required: true,
+    index: { expireAfterSeconds: 0 } // TTL index
+  },
+  payload: {
+    type: mongoose.Schema.Types.Mixed,
+    required: true
+  },
+  processed: {
+    type: Boolean,
+    default: false
+  }
+})
+
+const ScheduledMessage = mongoose.model('ScheduledMessage', scheduledMessageSchema)
+module.exports = ScheduledMessage
+```
+
+**2. Create Messages When Scheduling Talks**
+
+```javascript
+// lib/schedulingLogic.js
+const ScheduledMessage = require('../models/scheduledMessage')
+
+async function scheduleSpeaker({...}) {
+  // ... existing scheduling logic ...
+  
+  const savedSpeaker = await speaker.save()
+  
+  // Schedule reminders
+  const talkDate = savedSpeaker.scheduledDate
+  const reminder24h = new Date(talkDate)
+  reminder24h.setHours(reminder24h.getHours() - 24)
+  
+  const reminder1h = new Date(talkDate)
+  reminder1h.setHours(reminder1h.getHours() - 1)
+  
+  await ScheduledMessage.create([
+    {
+      type: 'talk_reminder_24h',
+      scheduledFor: reminder24h,
+      payload: { speakerId: savedSpeaker._id }
+    },
+    {
+      type: 'talk_reminder_1h',
+      scheduledFor: reminder1h,
+      payload: { speakerId: savedSpeaker._id }
+    }
+  ])
+  
+  return savedSpeaker
+}
+```
+
+**3. Listen for Expired Documents**
+
+```javascript
+// lib/proactive/mongoScheduler.js
+const ScheduledMessage = require('../../models/scheduledMessage')
+const mongoose = require('mongoose')
+
+class MongoScheduler {
+  constructor(client) {
+    this.client = client
+    this.changeStream = null
+  }
+
+  start() {
+    // Poll for expired messages every minute
+    setInterval(async () => {
+      await this.processExpiredMessages()
+    }, 60 * 1000)
+    
+    // Also listen to change streams for immediate processing
+    const collection = mongoose.connection.db.collection('scheduledmessages')
+    this.changeStream = collection.watch(
+      [{ $match: { 'fullDocument.processed': false } }],
+      { fullDocument: 'updateLookup' }
+    )
+    
+    this.changeStream.on('change', async (change) => {
+      if (change.operationType === 'update') {
+        await this.processMessage(change.fullDocument)
+      }
+    })
+  }
+
+  async processExpiredMessages() {
+    const now = new Date()
+    const expired = await ScheduledMessage.find({
+      scheduledFor: { $lte: now },
+      processed: false
+    })
+    
+    for (const message of expired) {
+      await this.processMessage(message)
+    }
+  }
+
+  async processMessage(messageDoc) {
+    try {
+      // Process based on message type
+      switch (messageDoc.type) {
+        case 'talk_reminder_24h':
+        case 'talk_reminder_1h':
+          await this.sendTalkReminder(messageDoc)
+          break
+        case 'weekly_announcement':
+          await this.sendWeeklyAnnouncement(messageDoc)
+          break
+      }
+      
+      // Mark as processed
+      messageDoc.processed = true
+      await messageDoc.save()
+    } catch (error) {
+      console.error('Error processing scheduled message:', error)
+    }
+  }
+}
+
+module.exports = { MongoScheduler }
+```
+
+**Pros:**
+- Persistent across bot restarts
+- Database-driven (single source of truth)
+- Can query and debug scheduled messages
+- Scales well
+
+**Cons:**
+- More complex implementation
+- Requires MongoDB change streams (MongoDB 3.6+)
+- TTL indexes have some delay (up to 60 seconds)
+- More database queries
+
+### Comparison Summary
+
+| Approach | Complexity | Persistence | External Deps | Precision | Best For |
+|---------|-----------|-------------|---------------|-----------|----------|
+| External Cron | Medium | Low | Yes | Medium | Multi-instance deployments |
+| node-cron | Low | Low | No | High | Single-instance bots |
+| **Docker Cron** | **Low-Medium** | **Low** | **No** | **High** | **Docker deployments (RECOMMENDED)** |
+| MongoDB TTL | High | High | No | Medium | Production systems needing persistence |
+
+**Note:** Since the bot runs in Docker (`node:lts-alpine`), using system cron inside the container is a viable and simple option. It leverages standard Unix cron without external dependencies and provides precise timing control.
+
+## Implementation Plan
+
+### Phase 1: Foundation (Core Infrastructure)
+
+1. **Set up Docker cron infrastructure**
+   - Update `Dockerfile` to install `dcron` (Alpine cron)
+   - Create `crontab` file with scheduled jobs
+   - Create `docker-entrypoint.sh` to start cron daemon alongside Node.js
+   - Create shell scripts for cron jobs (`bin/check-reminders.sh`, `bin/weekly-announcement.sh`)
+
+2. **Create proactive messaging module structure**
+   - Create `lib/proactive/` directory
+   - Add `index.js` with basic service structure
+   - Add `talkReminders.js` for reminder logic
+   - Add `weeklyAnnouncements.js` for weekly schedule posts
+
+3. **Add HTTP endpoints for cron triggers**
+   - Create `api/proactive-trigger.js` with `/check-reminders` endpoint
+   - Register route in `server.js`
+   - Add authentication (CRON_SECRET env var or localhost-only)
+
+4. **Add database schema updates**
+   - Update `models/scheduledSpeaker.js` to include reminder tracking fields
+   - Create migration script if needed
+
+### Phase 2: Talk Reminders
+
+4. **Implement talk reminder logic**
+   - Create `lib/proactive/talkReminders.js`
+   - Implement 24-hour reminder check
+   - Implement 1-hour reminder check
+   - Add reminder message templates
+
+5. **Add reminder sending functionality**
+   - Implement `sendTalkReminder()` function
+   - Handle thread vs DM fallback
+   - Add error handling and logging
+
+6. **Test talk reminders**
+   - Create test cases for reminder timing
+   - Test with scheduled talks
+   - Verify reminder flags are set correctly
+
+### Phase 3: Weekly Announcements
+
+7. **Implement weekly schedule announcements**
+   - Create `lib/proactive/weeklyAnnouncements.js`
+   - Add configuration for announcement channel and time
+   - Format upcoming schedule for announcement
+
+8. **Add announcement scheduling**
+   - Schedule weekly checks (every Monday)
+   - Send formatted schedule to announcement channel
+
+### Phase 4: Event-Based Notifications
+
+9. **Add reschedule notifications**
+   - Hook into `rescheduleSpeaker()` function
+   - Send notification when talk is rescheduled
+   - Update message handler to trigger notifications
+
+10. **Add cancellation notifications**
+    - Hook into `cancelSpeaker()` function
+    - Send notification when talk is cancelled
+
+### Phase 5: Configuration and Polish
+
+11. **Add configuration options**
+    - Add reminder timing configuration to `config/index.js`
+    - Add announcement channel/time configuration
+    - Make intervals configurable
+
+12. **Add monitoring and logging**
+    - Log all proactive messages sent
+    - Add metrics for message delivery success/failure
+    - Add health check for proactive service
+
+13. **Documentation**
+    - Update README with proactive messaging features
+    - Document configuration options
+    - Add examples of proactive messages
+
+## Open Questions
+
+1. **Channel Selection**: How should we determine which channel to send proactive messages to?
+   - Should there be a configured "announcements" channel?
+   - Should reminders go to the original signup thread or a new thread?
+   - Should we support DMs as an option?
+
+2. **Timezone Handling**: How should we handle timezones for reminders?
+   - Use UTC consistently (current approach)?
+   - Allow per-user timezone preferences?
+   - Use server timezone?
+
+3. **Message Rate Limits**: How should we handle Discord rate limits?
+   - Implement rate limiting in the proactive service?
+   - Batch messages when possible?
+   - Add delays between messages?
+
+4. **Failure Recovery**: What should happen if a message fails to send?
+   - Retry immediately?
+   - Retry after delay?
+   - Log and skip?
+   - Notify admins?
+
+5. **User Preferences**: Should users be able to opt out of proactive messages?
+   - Add preference flags to user model?
+   - Respect Discord notification settings?
+   - Provide slash command to manage preferences?
+
+6. **Testing Strategy**: How should we test time-based functionality?
+   - Use time mocking in tests?
+   - Create test talks with near-future dates?
+   - Add integration tests with real timing?
+
+## References
+
+- [Message Sending and Runtime Architecture Analysis](./reference/01-message-sending-and-runtime-architecture-analysis.md) - Current message sending patterns
+- [Discord.js Documentation](https://discord.js.org/) - Discord.js API reference
+- [Node.js Timers](https://nodejs.org/api/timers.html) - Node.js timer APIs
+- [MongoDB Date Queries](https://www.mongodb.com/docs/manual/reference/operator/query/date/) - MongoDB date query patterns

--- a/ttmp/2025/12/19/ADD_PROACTIVE_MESSAGES--add-proactive-messages/design-doc/02-cron-driven-proactive-messaging-detailed-implementation-plan.md
+++ b/ttmp/2025/12/19/ADD_PROACTIVE_MESSAGES--add-proactive-messages/design-doc/02-cron-driven-proactive-messaging-detailed-implementation-plan.md
@@ -1,0 +1,234 @@
+---
+Title: 'Cron-driven Proactive Messaging: Detailed Implementation Plan'
+Ticket: ADD_PROACTIVE_MESSAGES
+Status: active
+Topics:
+    - discord
+    - bot
+    - scheduling
+    - ops
+DocType: design-doc
+Intent: long-term
+Owners: []
+RelatedFiles:
+    - Path: Dockerfile
+      Note: Add dcron + crontab + entrypoint to run cron alongside Node
+    - Path: index.js
+      Note: Ensures Discord + HTTP server are running for cron to call
+    - Path: lib/discord/index.js
+      Note: Discord client instance used by proactive jobs
+    - Path: lib/schedulingLogic.js
+      Note: Source of scheduled talks; reminders read from same model
+    - Path: models/scheduledSpeaker.js
+      Note: Add reminders.sentTminus1At/sentDayOfAt fields for idempotency
+    - Path: server.js
+      Note: Mount localhost-only internal proactive trigger routes
+ExternalSources: []
+Summary: Step-by-step implementation plan for Docker cron-driven proactive messaging (cron -> localhost HTTP triggers -> Discord send)
+LastUpdated: 2025-12-19T13:20:12.226888-08:00
+---
+
+
+# Cron-driven Proactive Messaging: Detailed Implementation Plan
+
+## Executive Summary
+
+Implement proactive messages using **system cron inside the Docker container** (Alpine `dcron`) to trigger **localhost-only HTTP endpoints** on the already-running Express server. Those endpoints invoke “jobs” that use the already-connected Discord client to send messages (DMs or channel posts).
+
+This approach keeps scheduling concerns in cron (standard ops practice), avoids in-process polling, and avoids starting additional Discord connections from cron scripts. The bot remains a single long-lived process (`node index.js`), and cron simply “pokes” it.
+
+## Problem Statement
+
+The current bot is reactive: it sends messages only as direct replies to Discord messages or slash commands. We need time-based proactive messaging (e.g., speaker reminders, weekly schedule posts) that will run reliably in production.
+
+Constraints from the current system:
+- The bot runs as a single Node process in Docker (`CMD ["node","index.js"]`).
+- Discord sending requires an authenticated, connected `discord.js` client.
+- The web server already exists (`server.js`) and can host internal endpoints.
+
+We want proactive messaging that is:
+- **Predictable** (explicit schedules, easy to change)
+- **Operationally standard** (cron)
+- **Safe** (no unauthenticated public endpoints)
+- **Idempotent** (no duplicate reminders)
+
+## Proposed Solution
+
+### High-level architecture
+
+```
+cron (dcron) in container
+  └─> curl http://127.0.0.1:3000/internal/proactive/<job>
+        └─> Express handler (server.js route)
+              └─> job runner (lib/proactive/jobs/*)
+                    └─> use existing Discord client instance to send
+                          └─> update MongoDB flags to prevent duplicates
+```
+
+### Components to add
+
+#### 1) Internal “job trigger” HTTP routes
+Add **localhost-only** routes under `POST /internal/proactive/...` that:
+- validate the caller is local (or requires a shared secret header as fallback)
+- call into job functions (no Discord logic in the route handler)
+- return a small JSON summary (counts, duration, errors)
+
+#### 2) Proactive job modules
+Add `lib/proactive/jobs/*` that implement:
+- `talkRemindersJob`: checks upcoming talks and sends reminders
+- `weeklyScheduleAnnouncementJob`: posts upcoming schedule to a configured channel
+
+Each job must be:
+- **idempotent** (safe if cron runs twice or container restarts)
+- **safe to run concurrently** (prefer a simple lock to avoid overlapping runs)
+
+#### 3) Docker cron
+Modify the Docker image to:
+- install `dcron`
+- add a root crontab (`/etc/crontabs/root`)
+- run `crond` alongside Node using an entrypoint script
+
+Cron entries call `curl` against localhost endpoints (not scripts that start Node/Discord).
+
+#### 4) Minimal persistence for idempotency
+Record “reminder for talk was sent” to avoid duplicates. The simplest approach is to add fields on `ScheduledSpeaker`:
+- `reminders.sentTminus1At`, `reminders.sentDayOfAt` (timestamps, not booleans)
+
+## Design Decisions
+
+### Scheduling mechanism: Docker cron + localhost triggers
+- **Why cron**: explicit schedules and standard ops tooling.
+- **Why localhost HTTP**: cron should not create a second Discord connection; it should trigger the running bot instance.
+
+### Security: local-only route + optional secret
+- Primary guard: accept only loopback (`127.0.0.1`, `::1`) / `req.socket.remoteAddress`.
+- Secondary guard (optional): `X-Cron-Secret` header matching `CRON_SECRET` env var.
+
+### Locks to avoid overlapping job runs
+Cron schedules can overlap if a job runs long. Use a lock so only one instance of a job runs at a time:
+- simplest: in-memory lock keyed by job name (single container)
+- if multi-instance later: Mongo-based distributed lock
+
+### Time semantics
+`scheduledDate` is stored normalized to midnight UTC; talks are currently “on a date” not “at a time”. Reminder semantics should be date-based unless we add a talk time.
+
+Initial reminders:
+- **T-1 day** reminder: send at a configured hour UTC daily, targeting talks scheduled “tomorrow”
+- **Day-of** reminder: send at a configured hour UTC daily, targeting talks scheduled “today”
+
+## Design Decisions
+
+<!-- superseded by cron-specific Design Decisions above -->
+
+## Alternatives Considered
+
+### In-process polling (`setInterval`)
+- **Pros**: no Docker/cron changes
+- **Cons**: always-on polling; schedules live in code; less ops-friendly
+
+### External cron (GitHub Actions / EventBridge)
+- **Pros**: no cron daemon in container
+- **Cons**: requires public HTTP endpoint + auth; more moving pieces
+
+## Implementation Plan
+
+### Phase 0 — Configuration (required)
+
+1. **Decide message destinations**
+   - Announcements channel id: `PROACTIVE_ANNOUNCEMENTS_CHANNEL_ID`
+   - Reminder delivery: DM speaker by default; optionally also post to signup thread if `threadId` exists.
+
+2. **Decide reminder schedule (UTC)**
+   - Example:
+     - T-1 day reminder: 16:00 UTC daily
+     - Day-of reminder: 16:00 UTC daily
+
+3. **Add env vars**
+   - `CRON_SECRET` (optional; used only if not loopback)
+   - `PROACTIVE_ANNOUNCEMENTS_CHANNEL_ID`
+   - `PROACTIVE_REMINDERS_ENABLED=true|false`
+   - `PROACTIVE_WEEKLY_ENABLED=true|false`
+
+### Phase 1 — Internal job trigger routes (Express)
+
+1. Create `api/proactive-internal.js`
+   - `POST /internal/proactive/check-reminders`
+   - `POST /internal/proactive/weekly-announcement`
+2. Wire in `server.js`:
+   - `app.use('/internal/proactive', proactiveInternalRouter)`
+3. Add security checks (loopback-only, optional secret)
+4. Return structured JSON results
+
+### Phase 2 — Implement job modules
+
+Create:
+- `lib/proactive/index.js`
+- `lib/proactive/locks.js`
+- `lib/proactive/jobs/talkReminders.js`
+- `lib/proactive/jobs/weeklyAnnouncement.js`
+
+#### Talk reminders job (date-based)
+
+Selection:
+- T-1 day reminders: `scheduledDate == tomorrowUTC && reminders.sentTminus1At == null`
+- Day-of reminders: `scheduledDate == todayUTC && reminders.sentDayOfAt == null`
+
+Delivery (per talk):
+- Prefer DM to the speaker (`client.users.fetch(...).then(user.send(...))`)
+- Fallback: if DM fails and `threadId` exists, `client.channels.fetch(threadId)` then `thread.send(...)`
+- Mark sent timestamp only on success; keep null on failure to retry next run
+
+#### Weekly announcement job
+
+Delivery:
+- Post to `PROACTIVE_ANNOUNCEMENTS_CHANNEL_ID`
+- Include upcoming talks (next N)
+
+### Phase 3 — Persistence changes for idempotency
+
+Update `models/scheduledSpeaker.js` to add:
+- `reminders.sentTminus1At: Date`
+- `reminders.sentDayOfAt: Date`
+
+Existing docs with missing fields are treated as “not sent yet”.
+
+### Phase 4 — Docker cron integration
+
+1. Update `Dockerfile`:
+   - install `dcron` (`apk add --no-cache dcron`)
+   - copy `/etc/crontabs/root`
+   - add `docker-entrypoint.sh` and use it as `ENTRYPOINT`
+2. Add `docker-entrypoint.sh`:
+   - `crond -f -l 2 &` then `exec "$@"`
+3. Add crontab:
+
+```
+0 16 * * * curl -fsS -X POST http://127.0.0.1:3000/internal/proactive/check-reminders || true
+0 15 * * 1 curl -fsS -X POST http://127.0.0.1:3000/internal/proactive/weekly-announcement || true
+```
+
+### Phase 5 — Tests & validation
+
+1. Unit tests (Tape):
+   - reminder job selection + idempotency with mocked time
+2. Manual:
+   - run container, then `curl -X POST http://127.0.0.1:3000/internal/proactive/check-reminders`
+
+### Phase 6 — Rollout
+
+1. Deploy with `PROACTIVE_*_ENABLED=false`; verify cron + endpoints.
+2. Enable reminders; monitor logs.
+3. Enable weekly announcement; confirm channel id.
+
+## Open Questions
+
+1. Do talks have a specific time? If yes, implement true “24h/1h before” reminders.
+2. Which channel id should receive weekly announcements?
+3. DM policy: DM-only vs DM+thread?
+4. Will we run multiple replicas? If yes, add distributed lock.
+
+## References
+
+- `ttmp/2025/12/19/ADD_PROACTIVE_MESSAGES--add-proactive-messages/reference/01-message-sending-and-runtime-architecture-analysis.md`
+- `ttmp/2025/12/19/ADD_PROACTIVE_MESSAGES--add-proactive-messages/design-doc/01-proactive-messaging-implementation-plan.md`
+- `Dockerfile`, `server.js`, `lib/discord/index.js`, `models/scheduledSpeaker.js`

--- a/ttmp/2025/12/19/ADD_PROACTIVE_MESSAGES--add-proactive-messages/index.md
+++ b/ttmp/2025/12/19/ADD_PROACTIVE_MESSAGES--add-proactive-messages/index.md
@@ -1,0 +1,62 @@
+---
+Title: Add Proactive Messages
+Ticket: ADD_PROACTIVE_MESSAGES
+Status: active
+Topics:
+    - discord
+    - bot
+DocType: index
+Intent: long-term
+Owners: []
+RelatedFiles: []
+ExternalSources: []
+Summary: "Add proactive messaging capabilities to the Discord bot"
+LastUpdated: 2025-12-19T13:06:01.837793-08:00
+---
+
+# Add Proactive Messages
+
+## Overview
+
+This ticket aims to add proactive messaging capabilities to the AI in Action Discord bot. Currently, the bot only responds to user messages and slash commands. We need to implement the ability for the bot to send messages proactively based on events, schedules, or other triggers.
+
+**Current State Analysis**: A comprehensive analysis of the message sending architecture and runtime has been completed. See the [Message Sending and Runtime Architecture Analysis](./reference/01-message-sending-and-runtime-architecture-analysis.md) document for details on:
+- How messages are currently sent (reply, thread creation, slash commands)
+- Runtime architecture (Discord client + HTTP server)
+- Event handling patterns
+- State management
+- LLM integration points
+
+**Next Steps**: Design proactive messaging patterns that integrate with the existing architecture.
+
+## Key Links
+
+- **[Message Sending and Runtime Architecture Analysis](./reference/01-message-sending-and-runtime-architecture-analysis.md)** - Comprehensive analysis of current message sending mechanisms and runtime architecture
+- **Related Files**: See frontmatter RelatedFiles field
+- **External Sources**: See frontmatter ExternalSources field
+
+## Status
+
+Current status: **active**
+
+## Topics
+
+- discord
+- bot
+
+## Tasks
+
+See [tasks.md](./tasks.md) for the current task list.
+
+## Changelog
+
+See [changelog.md](./changelog.md) for recent changes and decisions.
+
+## Structure
+
+- design/ - Architecture and design documents
+- reference/ - Prompt packs, API contracts, context summaries
+- playbooks/ - Command sequences and test procedures
+- scripts/ - Temporary code and tooling
+- various/ - Working notes and research
+- archive/ - Deprecated or reference-only artifacts

--- a/ttmp/2025/12/19/ADD_PROACTIVE_MESSAGES--add-proactive-messages/index.md
+++ b/ttmp/2025/12/19/ADD_PROACTIVE_MESSAGES--add-proactive-messages/index.md
@@ -1,7 +1,7 @@
 ---
 Title: Add Proactive Messages
 Ticket: ADD_PROACTIVE_MESSAGES
-Status: active
+Status: complete
 Topics:
     - discord
     - bot
@@ -10,9 +10,10 @@ Intent: long-term
 Owners: []
 RelatedFiles: []
 ExternalSources: []
-Summary: "Add proactive messaging capabilities to the Discord bot"
-LastUpdated: 2025-12-19T13:06:01.837793-08:00
+Summary: Add proactive messaging capabilities to the Discord bot
+LastUpdated: 2025-12-19T14:09:04.369865-08:00
 ---
+
 
 # Add Proactive Messages
 

--- a/ttmp/2025/12/19/ADD_PROACTIVE_MESSAGES--add-proactive-messages/playbook/01-proactive-messaging-testing-guide.md
+++ b/ttmp/2025/12/19/ADD_PROACTIVE_MESSAGES--add-proactive-messages/playbook/01-proactive-messaging-testing-guide.md
@@ -57,6 +57,38 @@ This guide covers how to test the proactive messaging feature end-to-end, from l
 
 ## Testing Approach
 
+### Phase 0: Quick Test with REPL (No Discord Required) ⚡
+
+The easiest way to test proactive messaging without setting up Discord is using the REPL test script. This uses the chat simulation client to test all functionality.
+
+```bash
+# Run the test script (no Discord token needed!)
+npm run test-proactive
+# or directly:
+node bin/test-proactive.js
+```
+
+**What it tests:**
+- ✅ Talk reminders job (T-1 and day-of)
+- ✅ Weekly announcement job
+- ✅ Idempotency (no duplicate sends)
+- ✅ Disabled features handling
+- ✅ DM and channel message sending
+
+**What you'll see:**
+- Test talks created in MongoDB
+- DMs "sent" to simulated users (printed to console)
+- Channel announcements "posted" (printed to console)
+- Job results with counts and status
+- Automatic cleanup of test data
+
+**Prerequisites:**
+- MongoDB running (uses your `MONGO_URI`)
+- No Discord token needed!
+- Environment variables optional (script sets them for testing)
+
+This is the fastest way to verify the proactive messaging logic works correctly before testing with real Discord.
+
 ### Phase 1: Local Testing (Without Docker)
 
 Test the endpoints and job logic locally before containerizing.

--- a/ttmp/2025/12/19/ADD_PROACTIVE_MESSAGES--add-proactive-messages/playbook/01-proactive-messaging-testing-guide.md
+++ b/ttmp/2025/12/19/ADD_PROACTIVE_MESSAGES--add-proactive-messages/playbook/01-proactive-messaging-testing-guide.md
@@ -1,0 +1,494 @@
+---
+Title: Proactive Messaging Testing Guide
+Ticket: ADD_PROACTIVE_MESSAGES
+Status: active
+Topics:
+    - discord
+    - bot
+    - testing
+DocType: playbook
+Intent: long-term
+Owners: []
+RelatedFiles:
+    - Path: Dockerfile
+      Note: Docker setup to test
+    - Path: api/proactive-internal.js
+      Note: Endpoints to test
+    - Path: crontab
+      Note: Cron schedule to verify
+    - Path: lib/proactive/jobs/talkReminders.js
+      Note: Job logic to validate
+    - Path: lib/proactive/jobs/weeklyAnnouncement.js
+      Note: Job logic to validate
+ExternalSources: []
+Summary: Step-by-step guide for testing proactive messaging functionality
+LastUpdated: 2025-12-19T14:00:00-08:00
+---
+
+
+# Proactive Messaging Testing Guide
+
+This guide covers how to test the proactive messaging feature end-to-end, from local development to production validation.
+
+## Prerequisites
+
+1. **Environment Variables** - Add these to your `.env` file:
+   ```bash
+   # Enable proactive features
+   PROACTIVE_REMINDERS_ENABLED=true
+   PROACTIVE_WEEKLY_ENABLED=true
+   
+   # Discord channel ID for weekly announcements
+   PROACTIVE_ANNOUNCEMENTS_CHANNEL_ID=your-channel-id-here
+   
+   # Optional: Secret for non-loopback access (for multi-instance deployments)
+   CRON_SECRET=your-secret-here
+   
+   # Required: Standard bot config
+   DISCORD_TOKEN=your-bot-token
+   DISCORD_CLIENT_ID=your-client-id
+   DISCORD_GUILD_ID=your-guild-id
+   MONGO_URI=mongodb://localhost:27017/aiia-bot
+   ```
+
+2. **Get Channel ID** - To find your Discord channel ID:
+   - Enable Developer Mode in Discord (User Settings → Advanced → Developer Mode)
+   - Right-click the channel → Copy ID
+
+## Testing Approach
+
+### Phase 1: Local Testing (Without Docker)
+
+Test the endpoints and job logic locally before containerizing.
+
+#### 1.1 Test Security Middleware
+
+Verify that endpoints reject non-loopback requests:
+
+```bash
+# Start the bot locally
+npm start
+
+# In another terminal, test loopback access (should work)
+curl -X POST http://127.0.0.1:3000/internal/proactive/check-reminders
+
+# Test non-loopback access (should fail with 403)
+curl -X POST http://localhost:3000/internal/proactive/check-reminders \
+  -H "X-Forwarded-For: 192.168.1.1"
+
+# Test with secret header (should work if CRON_SECRET is set)
+curl -X POST http://localhost:3000/internal/proactive/check-reminders \
+  -H "X-Forwarded-For: 192.168.1.1" \
+  -H "X-Cron-Secret: your-secret-here"
+```
+
+Expected results:
+- Loopback requests return 200 with job results
+- Non-loopback without secret return 403
+- Non-loopback with valid secret return 200
+
+#### 1.2 Test Endpoints Manually
+
+Create test data and trigger jobs:
+
+```bash
+# Start bot
+npm start
+
+# In MongoDB shell or using a script, create test talks:
+# - One scheduled for tomorrow (for T-1 reminder)
+# - One scheduled for today (for day-of reminder)
+```
+
+**Create test talks via MongoDB:**
+
+```javascript
+// Connect to MongoDB
+use aiia-bot
+
+// Create talk for tomorrow (T-1 reminder test)
+db.scheduledSpeakers.insertOne({
+  discordUserId: "your-discord-user-id",
+  discordUsername: "TestUser",
+  topic: "Test Talk for Tomorrow",
+  scheduledDate: new Date(Date.now() + 24*60*60*1000), // Tomorrow
+  threadId: "optional-thread-id"
+})
+
+// Create talk for today (day-of reminder test)
+db.scheduledSpeakers.insertOne({
+  discordUserId: "your-discord-user-id",
+  discordUsername: "TestUser",
+  topic: "Test Talk for Today",
+  scheduledDate: new Date(), // Today (normalized to midnight UTC)
+  threadId: "optional-thread-id"
+})
+```
+
+**Trigger reminders job:**
+
+```bash
+curl -X POST http://127.0.0.1:3000/internal/proactive/check-reminders \
+  -H "Content-Type: application/json" | jq
+```
+
+Expected response:
+```json
+{
+  "job": "talk-reminders",
+  "status": "success",
+  "duration": 123,
+  "reminders": {
+    "tminus1Sent": 1,
+    "dayOfSent": 1,
+    "errors": []
+  },
+  "timestamp": "2025-12-19T22:00:00.000Z"
+}
+```
+
+**Verify in Discord:**
+- Check DMs from the bot (should receive reminders)
+- If DM fails, check the thread (fallback should work)
+
+**Verify in MongoDB:**
+
+```javascript
+// Check that reminder timestamps were set
+db.scheduledSpeakers.find({
+  topic: { $in: ["Test Talk for Tomorrow", "Test Talk for Today"] }
+}).pretty()
+
+// Should show:
+// - reminders.sentTminus1At for tomorrow's talk
+// - reminders.sentDayOfAt for today's talk
+```
+
+**Test idempotency (no duplicate sends):**
+
+```bash
+# Run the job again immediately
+curl -X POST http://127.0.0.1:3000/internal/proactive/check-reminders | jq
+
+# Should show:
+# "tminus1Sent": 0,
+# "dayOfSent": 0
+# (no new reminders sent because timestamps already set)
+```
+
+**Trigger weekly announcement:**
+
+```bash
+curl -X POST http://127.0.0.1:3000/internal/proactive/weekly-announcement | jq
+```
+
+Expected response:
+```json
+{
+  "job": "weekly-announcement",
+  "status": "success",
+  "duration": 45,
+  "announcement": {
+    "posted": true,
+    "talksCount": 3,
+    "error": null
+  },
+  "timestamp": "2025-12-19T22:00:00.000Z"
+}
+```
+
+**Verify in Discord:**
+- Check the announcements channel for the weekly schedule post
+
+### Phase 2: Docker Container Testing
+
+Test the full Docker setup with cron integration.
+
+#### 2.1 Build Docker Image
+
+```bash
+# Build the image
+docker build -t ai-in-action-bot .
+
+# Verify cron is installed
+docker run --rm ai-in-action-bot crond --help
+```
+
+#### 2.2 Run Container with Environment Variables
+
+```bash
+# Create .env file with all required variables
+cat > .env << EOF
+DISCORD_TOKEN=your-token
+DISCORD_CLIENT_ID=your-client-id
+DISCORD_GUILD_ID=your-guild-id
+MONGO_URI=mongodb://host.docker.internal:27017/aiia-bot
+PROACTIVE_REMINDERS_ENABLED=true
+PROACTIVE_WEEKLY_ENABLED=true
+PROACTIVE_ANNOUNCEMENTS_CHANNEL_ID=your-channel-id
+EOF
+
+# Run container
+docker run --env-file .env \
+  -p 3000:3000 \
+  --name aiia-bot-test \
+  ai-in-action-bot
+```
+
+**Verify both processes are running:**
+
+```bash
+# Check container logs
+docker logs aiia-bot-test
+
+# Should see:
+# - "Ready! Logged in as BotName#1234" (Discord bot)
+# - "AIIA Bot listening on port 3000" (HTTP server)
+# - Cron daemon running (no errors)
+```
+
+**Verify cron is running:**
+
+```bash
+# Exec into container
+docker exec aiia-bot-test ps aux | grep crond
+
+# Should show crond process running
+```
+
+#### 2.3 Test Endpoints from Host
+
+```bash
+# Test reminders endpoint
+curl -X POST http://localhost:3000/internal/proactive/check-reminders | jq
+
+# Test weekly announcement endpoint
+curl -X POST http://localhost:3000/internal/proactive/weekly-announcement | jq
+```
+
+#### 2.4 Test Cron Jobs Manually
+
+**Option A: Trigger cron job directly in container**
+
+```bash
+# Exec into container
+docker exec -it aiia-bot-test sh
+
+# Manually run cron job
+curl -fsS -X POST http://127.0.0.1:3000/internal/proactive/check-reminders
+
+# Exit container
+exit
+```
+
+**Option B: Wait for scheduled cron execution**
+
+Cron jobs are scheduled for:
+- Daily at 16:00 UTC: reminders
+- Mondays at 15:00 UTC: weekly announcement
+
+To test immediately, you can temporarily modify the crontab:
+
+```bash
+# Exec into container
+docker exec -it aiia-bot-test sh
+
+# Edit crontab (for testing only)
+vi /etc/crontabs/root
+
+# Change to run every minute for testing:
+# * * * * * curl -fsS -X POST http://127.0.0.1:3000/internal/proactive/check-reminders || true
+
+# Restart cron (or restart container)
+killall crond
+crond -f -l 2 &
+
+# Watch logs
+docker logs -f aiia-bot-test
+```
+
+### Phase 3: Edge Case Testing
+
+#### 3.1 Test Disabled Features
+
+```bash
+# Set in .env
+PROACTIVE_REMINDERS_ENABLED=false
+PROACTIVE_WEEKLY_ENABLED=false
+
+# Restart container
+docker restart aiia-bot-test
+
+# Trigger jobs
+curl -X POST http://localhost:3000/internal/proactive/check-reminders | jq
+
+# Should return:
+# {
+#   "skipped": true,
+#   "reason": "disabled",
+#   ...
+# }
+```
+
+#### 3.2 Test DM Failure Fallback
+
+Create a test scenario where DM fails:
+
+```javascript
+// In MongoDB, create talk with invalid user ID
+db.scheduledSpeakers.insertOne({
+  discordUserId: "invalid-user-id-999999",
+  discordUsername: "NonExistentUser",
+  topic: "Test DM Failure",
+  scheduledDate: new Date(),
+  threadId: "valid-thread-id" // This should be used as fallback
+})
+```
+
+Trigger job and verify:
+- DM attempt fails (expected)
+- Message is sent to thread instead (fallback works)
+- Reminder timestamp is still set (successful send)
+
+#### 3.3 Test Missing Channel ID
+
+```bash
+# Unset channel ID
+export PROACTIVE_ANNOUNCEMENTS_CHANNEL_ID=""
+
+# Trigger weekly announcement
+curl -X POST http://localhost:3000/internal/proactive/weekly-announcement | jq
+
+# Should return error about missing channel ID
+```
+
+#### 3.4 Test Locking Mechanism
+
+```bash
+# Trigger job twice rapidly
+curl -X POST http://localhost:3000/internal/proactive/check-reminders &
+curl -X POST http://localhost:3000/internal/proactive/check-reminders &
+
+# Wait for both to complete
+wait
+
+# Check logs - second request should show "skipped" with "already_running"
+```
+
+### Phase 4: Production Validation Checklist
+
+Before enabling in production:
+
+- [ ] **Environment Variables Set**
+  - [ ] `PROACTIVE_REMINDERS_ENABLED=true`
+  - [ ] `PROACTIVE_WEEKLY_ENABLED=true`
+  - [ ] `PROACTIVE_ANNOUNCEMENTS_CHANNEL_ID` is valid
+  - [ ] `CRON_SECRET` set (if using multi-instance)
+
+- [ ] **Container Running**
+  - [ ] Both cron and Node processes running
+  - [ ] No errors in container logs
+  - [ ] Discord bot connected and ready
+
+- [ ] **Endpoints Accessible**
+  - [ ] `curl http://localhost:3000/health` returns 200
+  - [ ] Internal endpoints respond correctly
+  - [ ] Security middleware blocks non-loopback (if CRON_SECRET not set)
+
+- [ ] **Test Data Created**
+  - [ ] Talk scheduled for tomorrow (T-1 test)
+  - [ ] Talk scheduled for today (day-of test)
+  - [ ] Multiple upcoming talks (weekly announcement test)
+
+- [ ] **Manual Trigger Successful**
+  - [ ] Reminders job sends DMs
+  - [ ] Weekly announcement posts to channel
+  - [ ] Database timestamps updated correctly
+  - [ ] No duplicate sends on re-run
+
+- [ ] **Cron Schedule Verified**
+  - [ ] Cron jobs scheduled correctly (check `/etc/crontabs/root` in container)
+  - [ ] Times are in UTC (16:00 daily, 15:00 Mondays)
+
+- [ ] **Monitoring Setup**
+  - [ ] Container logs accessible
+  - [ ] Job results logged (check for JSON responses)
+  - [ ] Error alerts configured (if applicable)
+
+## Troubleshooting
+
+### Endpoints Return 403
+
+**Problem:** `curl` returns 403 Forbidden
+
+**Solutions:**
+- Ensure you're using `127.0.0.1` (not `localhost`)
+- If testing from outside container, set `CRON_SECRET` and use header
+- Check middleware logs for rejection reason
+
+### No Reminders Sent
+
+**Problem:** Job runs but no reminders sent
+
+**Check:**
+- `PROACTIVE_REMINDERS_ENABLED=true` in environment
+- Talks exist with correct dates (tomorrow/today in UTC)
+- Reminder timestamps not already set (check MongoDB)
+- Discord bot has permission to DM users
+- User IDs are valid Discord user IDs
+
+### Cron Jobs Not Running
+
+**Problem:** Cron jobs don't execute on schedule
+
+**Check:**
+- Cron daemon is running: `docker exec container ps aux | grep crond`
+- Crontab file exists: `docker exec container cat /etc/crontabs/root`
+- Container timezone is UTC (cron uses container's timezone)
+- Check cron logs: `docker logs container | grep cron`
+
+### Database Timestamps Not Updating
+
+**Problem:** Reminders sent but timestamps not saved
+
+**Check:**
+- MongoDB connection working
+- Schema includes `reminders` field (should be automatic)
+- No database errors in logs
+- Verify with: `db.scheduledSpeakers.findOne({ topic: "Test Talk" })`
+
+## Quick Test Script
+
+Save this as `test-proactive.sh`:
+
+```bash
+#!/bin/bash
+set -e
+
+BASE_URL="${1:-http://127.0.0.1:3000}"
+
+echo "Testing proactive messaging endpoints..."
+echo ""
+
+echo "1. Testing check-reminders endpoint..."
+curl -s -X POST "$BASE_URL/internal/proactive/check-reminders" | jq
+echo ""
+
+echo "2. Testing weekly-announcement endpoint..."
+curl -s -X POST "$BASE_URL/internal/proactive/weekly-announcement" | jq
+echo ""
+
+echo "3. Testing idempotency (run reminders again)..."
+curl -s -X POST "$BASE_URL/internal/proactive/check-reminders" | jq
+echo ""
+
+echo "Done!"
+```
+
+Make it executable and run:
+```bash
+chmod +x test-proactive.sh
+./test-proactive.sh
+# Or test Docker container:
+./test-proactive.sh http://localhost:3000
+```

--- a/ttmp/2025/12/19/ADD_PROACTIVE_MESSAGES--add-proactive-messages/reference/01-message-sending-and-runtime-architecture-analysis.md
+++ b/ttmp/2025/12/19/ADD_PROACTIVE_MESSAGES--add-proactive-messages/reference/01-message-sending-and-runtime-architecture-analysis.md
@@ -1,0 +1,327 @@
+---
+Title: Message Sending and Runtime Architecture Analysis
+Ticket: ADD_PROACTIVE_MESSAGES
+Status: active
+Topics:
+    - discord
+    - bot
+DocType: reference
+Intent: long-term
+Owners: []
+RelatedFiles:
+    - Path: config/index.js
+      Note: Configuration management loading environment variables for Discord
+    - Path: index.js
+      Note: Application entry point that starts both Discord client and HTTP server
+    - Path: lib/discord/commands/check.js
+      Note: Example slash command implementation showing interaction.reply() pattern
+    - Path: lib/discord/index.js
+      Note: Discord client creation
+    - Path: lib/llm/index.js
+      Note: LLM integration service using OpenRouter API for intent detection and natural language processing
+    - Path: lib/mongo/index.js
+      Note: MongoDB connection and health check used by HTTP server
+    - Path: lib/schedulingLogic.js
+      Note: Core scheduling functions used by message handler to find dates and book talks
+    - Path: lib/shared/message-handler.js
+      Note: Centralized message handling logic with intent detection and state machine for thread conversations
+    - Path: lib/talkHistory.js
+      Note: Talk history queries used for query_talks intent handling
+    - Path: server.js
+      Note: Express HTTP server with health check endpoint and API routes
+ExternalSources: []
+Summary: Comprehensive analysis of how messages are sent in the Discord bot application, including runtime architecture, event handling, and message flow patterns
+LastUpdated: 2025-12-19T13:08:16.98119-08:00
+---
+
+
+
+# Message Sending and Runtime Architecture Analysis
+
+## Goal
+
+This document provides a comprehensive overview of how messages are sent in the AI in Action Discord bot application, including the runtime architecture, event handling mechanisms, and all code paths that result in messages being sent to Discord channels or users.
+
+## Context
+
+The bot operates as a dual-purpose application:
+1. **Discord Bot**: Responds to user messages and slash commands in Discord
+2. **HTTP Server**: Provides health checks and API endpoints
+
+Understanding the message sending mechanisms is critical for implementing proactive messaging features, as we need to know:
+- Where messages can be sent from
+- What APIs are available for sending messages
+- How the runtime initializes and maintains connections
+- What patterns exist for message composition and delivery
+
+## Runtime Architecture
+
+### Application Entry Point
+
+The application starts in `index.js`, which:
+1. Imports the Discord client (`lib/discord/index.js`)
+2. Imports the Express server (`server.js`)
+3. Waits for Discord client to be ready
+4. Starts the HTTP server on port 3000 (or `process.env.PORT`)
+
+**Key Files:**
+- `index.js` - Entry point, coordinates Discord and HTTP server startup
+- `server.js` - Express HTTP server with health check and API routes
+- `lib/discord/index.js` - Discord client creation and event registration
+
+### Discord Client Initialization
+
+The Discord client is created in `lib/discord/index.js` via `createClient()`:
+
+1. **Client Configuration**: Uses `discord.js` Client with intents:
+   - `GatewayIntentBits.Guilds` - Access to guild information
+   - `GatewayIntentBits.GuildMessages` - Access to guild messages
+   - `GatewayIntentBits.MessageContent` - Access to message content
+
+2. **Command Loading**: Dynamically loads slash commands from `lib/discord/commands/`
+
+3. **Event Handlers Registered**:
+   - `Events.ClientReady` - Logs ready status, sets bot activity
+   - `interactionCreate` - Handles slash commands, buttons, autocomplete
+   - `Events.MessageCreate` - Handles all incoming messages
+
+4. **Message Handler**: Creates shared message handler via `createMessageHandler()` from `lib/shared/message-handler.js`
+
+5. **Login**: Calls `client.login(token)` to connect to Discord
+
+### State Management
+
+The bot maintains in-memory state:
+- `activeSignups` object: Maps thread IDs to signup state objects
+  - Structure: `{ threadId: { userId, state, topic?, proposedDates?, targetUserId?, targetUsername?, lastUpdated? } }`
+  - States include: `awaiting_topic`, `awaiting_date_selection`, `awaiting_reschedule_date_selection`, etc.
+
+## Message Sending Mechanisms
+
+### 1. Reply to Messages (`message.reply()`)
+
+**Primary Method**: Used throughout `lib/shared/message-handler.js`
+
+**Pattern**:
+```javascript
+await message.reply("Response text here")
+```
+
+**Usage Locations**:
+- Thread state handlers (topic collection, date selection)
+- Intent-based responses (sign_up, view_schedule, cancel_talk, etc.)
+- Error messages and clarifications
+
+**Key Characteristics**:
+- Replies in the same channel/thread as the original message
+- Mentions the original author
+- Returns a Promise that resolves to the sent Message object
+
+### 2. Thread Creation and Messaging (`message.startThread()` + `thread.send()`)
+
+**Pattern**:
+```javascript
+const thread = await message.startThread({
+  name: `Thread Name - ${message.author.username}`,
+  autoArchiveDuration: 60,
+  reason: 'Reason for thread creation'
+})
+await thread.send("Message in new thread")
+```
+
+**Usage Locations**:
+- Sign-up flow: Creates thread for speaker sign-up process
+- Reschedule flow: Creates thread for rescheduling conversations
+- Schedule-for-others: Creates thread for scheduling other users
+- Zoom link requests: Creates thread for link sharing
+
+**Key Characteristics**:
+- Threads auto-archive after 60 minutes of inactivity
+- Thread name includes username for identification
+- Initial message sent via `thread.send()` after creation
+
+### 3. Slash Command Responses (`interaction.reply()`)
+
+**Pattern**:
+```javascript
+await interaction.reply({
+  content: "Response text",
+  ephemeral: true  // Optional: only visible to command user
+})
+```
+
+**Usage Locations**:
+- `lib/discord/commands/check.js` - Test command
+- Error handling in `handleInteraction()` for failed commands
+- Guild restriction messages for non-configured guilds
+
+**Key Characteristics**:
+- Must reply within 3 seconds or use `interaction.deferReply()`
+- Ephemeral replies are only visible to the command user
+- Can use `interaction.followUp()` for additional messages after initial reply
+
+### 4. Button Interaction Responses
+
+**Pattern**:
+```javascript
+// Button handlers are defined in command files
+cmd.handleButton(interaction, button)
+```
+
+**Usage Locations**:
+- Button interactions parsed via `parse(interaction.customId)`
+- Routed to command-specific handlers via `handleButton()` function
+
+## Message Flow Patterns
+
+### Incoming Message Flow
+
+1. **Message Received**: Discord.js emits `Events.MessageCreate`
+2. **Handler Invoked**: `sharedHandleMessage(message)` called
+3. **Filtering**:
+   - Ignores bot messages (`message.author.bot`)
+   - Filters by guild ID (only configured guild)
+4. **Routing**:
+   - **Thread Messages**: Checks `activeSignups[threadId]` for state-based handling
+   - **Mention Messages**: Checks if message starts with bot mention (`<@botId>`)
+   - **Intent Detection**: Uses LLM to classify user intent
+   - **State Machine**: Routes to appropriate handler based on detected intent and current state
+
+### Intent Detection Flow
+
+1. **LLM Classification**: Uses `completion()` from `lib/llm/index.js`
+2. **System Message**: Provides intent classification instructions
+3. **Detected Intents**:
+   - `sign_up` - User wants to schedule themselves
+   - `view_schedule` - User wants to see upcoming talks
+   - `cancel_talk` - User wants to cancel their talk
+   - `reschedule_talk` - User wants to reschedule their talk
+   - `schedule_for_others` - User wants to schedule someone else
+   - `cancel_talk_for_others` - User wants to cancel someone else's talk
+   - `reschedule_talk_for_others` - User wants to reschedule someone else's talk
+   - `query_talks` - User wants to search past talks
+   - `zoom_link` - User wants the zoom meeting link
+   - `repo` - User wants the GitHub repository link
+   - `other` - Fallback for unclear requests
+
+### Thread State Machine
+
+Thread-based conversations use a state machine pattern:
+
+**States**:
+- `awaiting_topic` - Waiting for user to provide presentation topic
+- `awaiting_date_selection` - Waiting for user to select from proposed dates
+- `awaiting_reschedule_date_selection` - Waiting for user to select new date
+- `awaiting_target_user` - Waiting for user to mention target person
+- `awaiting_topic_for_others` - Waiting for topic for scheduling others
+- `awaiting_date_selection_for_others` - Waiting for date selection for others
+- `awaiting_reschedule_date_selection_for_others` - Waiting for reschedule date for others
+- `awaiting_target_user_for_cancel` - Waiting for target user mention for cancellation
+- `awaiting_target_user_for_reschedule` - Waiting for target user mention for rescheduling
+
+**State Transitions**:
+- State stored in `activeSignups[threadId].state`
+- Updated as conversation progresses
+- Cleared when conversation completes or errors occur
+
+## LLM Integration
+
+### LLM Service (`lib/llm/index.js`)
+
+**Function**: `completion({ prompt, messages, systemMessage, maxTokens, model })`
+
+**Configuration**:
+- API: OpenRouter (`https://openrouter.ai/api/v1/chat/completions`)
+- Default Model: `openai/gpt-4o-mini`
+- Default Max Tokens: 100
+- Authentication: Bearer token from `config.openrouterApiKey`
+
+**Usage Patterns**:
+1. **Intent Detection**: Classifies user messages into action intents
+2. **Topic Validation**: Determines if user message is a valid presentation topic
+3. **Date Parsing**: Parses natural language date selections
+4. **Query Classification**: Classifies talk history queries
+
+## HTTP Server
+
+### Express Server (`server.js`)
+
+**Endpoints**:
+- `GET /health` - Health check with MongoDB connectivity check
+- `POST /auth` - Authentication test endpoint (requires auth middleware)
+
+**Middleware**:
+- JSON body parsing
+- Authentication middleware (`middleware/auth.js`)
+- Error handling middleware
+
+**Purpose**:
+- Health checks for deployment monitoring
+- API endpoints for external integrations (future)
+
+## Key Symbols and Functions
+
+### Discord Client Methods
+- `client.login(token)` - Connects to Discord Gateway
+- `client.user.setActivity()` - Sets bot's "watching" status
+- `client.users.fetch(userId)` - Fetches user object by ID
+- `client.commands.get(name)` - Gets registered slash command
+
+### Message Object Methods
+- `message.reply(content)` - Replies to message in same channel
+- `message.startThread(options)` - Creates thread from message
+- `message.channel.send(content)` - Sends message to channel (used by chat-sim)
+
+### Thread Object Methods
+- `thread.send(content)` - Sends message to thread
+
+### Interaction Object Methods
+- `interaction.reply(options)` - Replies to slash command
+- `interaction.followUp(options)` - Sends follow-up message
+- `interaction.deferReply()` - Defers reply (gives more time)
+- `interaction.isRepliable()` - Checks if interaction can be replied to
+- `interaction.isAutocomplete()` - Checks if autocomplete interaction
+- `interaction.isButton()` - Checks if button interaction
+- `interaction.isChatInputCommand()` - Checks if slash command
+
+## Usage Examples
+
+### Example 1: Simple Reply
+```javascript
+// In message handler
+await message.reply("Thanks for your message!")
+```
+
+### Example 2: Create Thread and Send Initial Message
+```javascript
+const thread = await message.startThread({
+  name: `Sign-up - ${message.author.username}`,
+  autoArchiveDuration: 60
+})
+await thread.send(`Hi ${message.author}, what's your topic?`)
+```
+
+### Example 3: Slash Command Response
+```javascript
+// In command execute function
+await interaction.reply({
+  content: `Hello ${userMention(user.id)}!`,
+  ephemeral: false
+})
+```
+
+### Example 4: State-Based Thread Response
+```javascript
+// In message handler, within thread state check
+if (signupInfo.state === 'awaiting_topic') {
+  signupInfo.topic = message.content.trim()
+  signupInfo.state = 'awaiting_date_selection'
+  await message.reply("Great! Here are available dates...")
+}
+```
+
+## Related
+
+- Design docs for proactive messaging implementation
+- Reference docs for Discord.js API patterns
+- Playbooks for testing message flows

--- a/ttmp/2025/12/19/ADD_PROACTIVE_MESSAGES--add-proactive-messages/reference/02-implementation-diary.md
+++ b/ttmp/2025/12/19/ADD_PROACTIVE_MESSAGES--add-proactive-messages/reference/02-implementation-diary.md
@@ -1,0 +1,88 @@
+---
+Title: Implementation Diary
+Ticket: ADD_PROACTIVE_MESSAGES
+Status: active
+Topics:
+    - discord
+    - bot
+DocType: reference
+Intent: long-term
+Owners: []
+RelatedFiles:
+    - Path: api/proactive-internal.js
+      Note: Created internal proactive router with placeholder endpoints (commit 547ef56)
+    - Path: config/index.js
+      Note: Added proactive messaging configuration (commit 547ef56)
+    - Path: middleware/loopback-only.js
+      Note: Created loopback-only security middleware for internal endpoints (commit 547ef56)
+    - Path: server.js
+      Note: Mounted proactive-internal router (commit 547ef56)
+ExternalSources: []
+Summary: Step-by-step implementation diary for proactive messaging feature
+LastUpdated: 2025-12-19T13:37:06.052438-08:00
+---
+
+
+# Implementation Diary
+
+## Goal
+
+This diary captures the step-by-step implementation of proactive messaging capabilities for the AI in Action Discord bot. It documents what changed, why it changed, what happened (including failures), and what we learned during the implementation process.
+
+## Step 1: Add Internal Proactive Router with Security
+
+This step establishes the foundation for proactive messaging by adding internal HTTP endpoints that will be triggered by cron jobs. The endpoints are secured to only accept requests from localhost (loopback), with an optional secret header fallback for non-loopback scenarios. This ensures that only cron running inside the container can trigger these jobs, preventing external access.
+
+**Commit (code):** 547ef56 — "Phase 1: Add internal proactive messaging router with security"
+
+### What I did
+- Added proactive messaging configuration to `config/index.js` (env vars: PROACTIVE_REMINDERS_ENABLED, PROACTIVE_WEEKLY_ENABLED, PROACTIVE_ANNOUNCEMENTS_CHANNEL_ID, CRON_SECRET)
+- Created `middleware/loopback-only.js` for securing internal endpoints (checks loopback IP or X-Cron-Secret header)
+- Created `api/proactive-internal.js` with two placeholder endpoints:
+  - `POST /internal/proactive/check-reminders`
+  - `POST /internal/proactive/weekly-announcement`
+- Mounted the router in `server.js` at `/internal/proactive`
+
+### Why
+- Need internal endpoints that cron can call via curl
+- Security requirement: only localhost should be able to trigger these jobs
+- Standardized JSON response format for job results (counts, duration, errors)
+
+### What worked
+- Router structure follows existing patterns (`api/auth-test.js`)
+- Security middleware checks both loopback IP and optional secret header
+- Endpoints return structured JSON responses ready for logging/monitoring
+- Linting passed without issues
+
+### What didn't work
+- N/A (initial implementation)
+
+### What I learned
+- Express router pattern in this codebase uses `autoCatch` wrapper for async handlers
+- Security middleware should check `req.socket.remoteAddress` for loopback detection
+- Optional secret header provides flexibility for future multi-instance deployments
+
+### What was tricky to build
+- Ensuring loopback detection covers all IPv4/IPv6 variants (127.0.0.1, ::1, ::ffff:127.0.0.1)
+- Deciding on security model: loopback-only vs secret header fallback (chose both for flexibility)
+
+### What warrants a second pair of eyes
+- Loopback detection logic - verify it works correctly in Docker container environment
+- Security model: confirm that loopback-only + optional secret is appropriate for production
+
+### What should be done in the future
+- Add integration tests for loopback-only middleware (test both loopback and non-loopback requests)
+- Add tests for internal endpoints security (verify 403 responses for non-loopback)
+- Document CRON_SECRET usage in deployment docs
+
+### Code review instructions
+- Start in `api/proactive-internal.js` - verify endpoint structure and response format
+- Check `middleware/loopback-only.js` - verify loopback detection logic
+- Review `server.js` - confirm router mounting
+- Test locally: `curl -X POST http://127.0.0.1:3000/internal/proactive/check-reminders` (should work)
+- Test security: `curl -X POST http://<external-ip>:3000/internal/proactive/check-reminders` (should 403)
+
+### Technical details
+- Endpoints return JSON with: `job`, `status`, `duration`, job-specific fields, `timestamp`
+- Security middleware checks `req.socket.remoteAddress` against loopback addresses
+- If `CRON_SECRET` env var is set, non-loopback requests can use `X-Cron-Secret` header

--- a/ttmp/2025/12/19/ADD_PROACTIVE_MESSAGES--add-proactive-messages/tasks.md
+++ b/ttmp/2025/12/19/ADD_PROACTIVE_MESSAGES--add-proactive-messages/tasks.md
@@ -1,0 +1,30 @@
+# Tasks
+
+## TODO
+
+
+- [ ] (Phase 0) Confirm talk time semantics (date-only vs specific time) and pick reminder strategy (T-1 day + day-of vs true 24h/1h)
+- [ ] (Phase 0) Decide cron schedules (UTC) for reminders + weekly announcement
+- [ ] (Phase 0) Decide destinations: announcements channel ID + reminder delivery policy (DM only vs DM+thread fallback)
+- [ ] (Phase 0) Define env vars and toggles: PROACTIVE_REMINDERS_ENABLED, PROACTIVE_WEEKLY_ENABLED, PROACTIVE_ANNOUNCEMENTS_CHANNEL_ID, optional CRON_SECRET
+- [ ] (Phase 1) Add internal proactive router (e.g. api/proactive-internal.js) with POST /internal/proactive/check-reminders
+- [ ] (Phase 1) Add POST /internal/proactive/weekly-announcement endpoint
+- [ ] (Phase 1) Secure internal endpoints: loopback-only guard (+ optional X-Cron-Secret)
+- [ ] (Phase 1) Mount internal proactive router in server.js
+- [ ] (Phase 1) Standardize job responses/logging (JSON summary with counts, duration, errors)
+- [ ] (Phase 2) Create proactive module skeleton: lib/proactive/index.js
+- [ ] (Phase 2) Add single-process locking utility (lib/proactive/locks.js) to prevent overlapping cron runs
+- [ ] (Phase 2) Implement talk reminders job (lib/proactive/jobs/talkReminders.js): select talks for today/tomorrow, build messages
+- [ ] (Phase 2) Implement delivery for reminders: DM speaker; if DM fails and threadId exists, post to thread
+- [ ] (Phase 2) Implement weekly announcement job (lib/proactive/jobs/weeklyAnnouncement.js): format upcoming schedule and post to configured channel
+- [ ] (Phase 3) Extend ScheduledSpeaker schema with reminder sent timestamps (e.g., reminders.sentTminus1At and reminders.sentDayOfAt)
+- [ ] (Phase 3) Ensure idempotency rules: only set sent timestamp on successful send; failed sends retry on next cron run
+- [ ] (Phase 3) Add/adjust scheduling queries needed by jobs (e.g., get talks for specific UTC dates)
+- [ ] (Phase 4) Docker: install dcron in Dockerfile
+- [ ] (Phase 4) Docker: add docker-entrypoint.sh to start crond alongside node index.js
+- [ ] (Phase 4) Docker: add crontab at /etc/crontabs/root with curl calls to localhost internal endpoints
+- [ ] (Phase 4) Docker: ensure cron and job logs reach container stdout/stderr
+- [ ] (Phase 5) Add unit tests for reminder selection + idempotency (mock time + stub discord send)
+- [ ] (Phase 5) Add unit/integration tests for internal endpoints security (loopback-only/secret)
+- [ ] (Phase 5) Manual validation: build/run container and trigger jobs via curl; verify DB flags update and Discord sends
+- [ ] (Phase 6) Rollout plan: ship with PROACTIVE_* disabled; enable reminders first; then weekly; document rollback steps

--- a/ttmp/2025/12/19/PROACTIVE_CHANNEL_CONFIG--store-proactive-channel-id-in-mongodb-with-discord-command/README.md
+++ b/ttmp/2025/12/19/PROACTIVE_CHANNEL_CONFIG--store-proactive-channel-id-in-mongodb-with-discord-command/README.md
@@ -1,0 +1,21 @@
+# Store proactive channel ID in MongoDB with Discord command
+
+This is the document workspace for ticket PROACTIVE_CHANNEL_CONFIG.
+
+## Structure
+
+- **design/**: Design documents and architecture notes
+- **reference/**: Reference documentation and API contracts
+- **playbooks/**: Operational playbooks and procedures
+- **scripts/**: Utility scripts and automation
+- **sources/**: External sources and imported documents
+- **various/**: Scratch or meeting notes, working notes
+- **archive/**: Optional space for deprecated or reference-only artifacts
+
+## Getting Started
+
+Use docmgr commands to manage this workspace:
+
+- Add documents: `docmgr add design-doc "My Design"`
+- Import sources: `docmgr import file path/to/doc.md`
+- Update metadata: `docmgr meta update --field Status --value review`

--- a/ttmp/2025/12/19/PROACTIVE_CHANNEL_CONFIG--store-proactive-channel-id-in-mongodb-with-discord-command/changelog.md
+++ b/ttmp/2025/12/19/PROACTIVE_CHANNEL_CONFIG--store-proactive-channel-id-in-mongodb-with-discord-command/changelog.md
@@ -1,0 +1,34 @@
+# Changelog
+
+## 2025-12-19
+
+- Initial workspace created
+
+
+## 2025-12-19
+
+Step 1: Created GuildSettings model and helper functions (commit 42e6d40)
+
+### Related Files
+
+- /Users/kball/git/ai-in-action-bot/lib/proactive/getGuildSettings.js — Query helpers
+- /Users/kball/git/ai-in-action-bot/models/guildSettings.js — New MongoDB schema
+
+
+## 2025-12-19
+
+Step 2: Created set-proactive-channel Discord command (commit eca63bc)
+
+### Related Files
+
+- /Users/kball/git/ai-in-action-bot/lib/discord/commands/set-proactive-channel.js — Discord command implementation
+
+
+## 2025-12-19
+
+Step 3: Updated weeklyAnnouncement job to use MongoDB (commit 994836d)
+
+### Related Files
+
+- /Users/kball/git/ai-in-action-bot/lib/proactive/jobs/weeklyAnnouncement.js — MongoDB lookup with config fallback
+

--- a/ttmp/2025/12/19/PROACTIVE_CHANNEL_CONFIG--store-proactive-channel-id-in-mongodb-with-discord-command/changelog.md
+++ b/ttmp/2025/12/19/PROACTIVE_CHANNEL_CONFIG--store-proactive-channel-id-in-mongodb-with-discord-command/changelog.md
@@ -43,3 +43,8 @@ Phase 5: Updated documentation (commit 3b0b721143804a0ecb371f23acd408a40e27a5be)
 - /Users/kball/git/ai-in-action-bot/README.md — Added /set-proactive-channel command documentation
 - /Users/kball/git/ai-in-action-bot/config/index.js — Marked PROACTIVE_ANNOUNCEMENTS_CHANNEL_ID as deprecated
 
+
+## 2025-12-19
+
+Ticket closed
+

--- a/ttmp/2025/12/19/PROACTIVE_CHANNEL_CONFIG--store-proactive-channel-id-in-mongodb-with-discord-command/changelog.md
+++ b/ttmp/2025/12/19/PROACTIVE_CHANNEL_CONFIG--store-proactive-channel-id-in-mongodb-with-discord-command/changelog.md
@@ -32,3 +32,14 @@ Step 3: Updated weeklyAnnouncement job to use MongoDB (commit 994836d)
 
 - /Users/kball/git/ai-in-action-bot/lib/proactive/jobs/weeklyAnnouncement.js — MongoDB lookup with config fallback
 
+
+## 2025-12-19
+
+Phase 5: Updated documentation (commit 3b0b721143804a0ecb371f23acd408a40e27a5be)
+
+### Related Files
+
+- /Users/kball/git/ai-in-action-bot/AGENTS.md — Updated proactive messaging section
+- /Users/kball/git/ai-in-action-bot/README.md — Added /set-proactive-channel command documentation
+- /Users/kball/git/ai-in-action-bot/config/index.js — Marked PROACTIVE_ANNOUNCEMENTS_CHANNEL_ID as deprecated
+

--- a/ttmp/2025/12/19/PROACTIVE_CHANNEL_CONFIG--store-proactive-channel-id-in-mongodb-with-discord-command/design-doc/01-proactive-channel-configuration-via-mongodb-and-discord-command.md
+++ b/ttmp/2025/12/19/PROACTIVE_CHANNEL_CONFIG--store-proactive-channel-id-in-mongodb-with-discord-command/design-doc/01-proactive-channel-configuration-via-mongodb-and-discord-command.md
@@ -1,0 +1,202 @@
+---
+Title: Proactive Channel Configuration via MongoDB and Discord Command
+Ticket: PROACTIVE_CHANNEL_CONFIG
+Status: active
+Topics:
+    - discord
+    - bot
+    - proactive
+    - configuration
+DocType: design-doc
+Intent: long-term
+Owners: []
+RelatedFiles:
+    - Path: models/guildSettings.js
+      Note: New model to store guild-specific configuration
+    - Path: lib/discord/commands/set-proactive-channel.js
+      Note: New Discord command to configure proactive channel
+    - Path: lib/proactive/jobs/weeklyAnnouncement.js
+      Note: Update to read channel ID from MongoDB instead of config
+    - Path: config/index.js
+      Note: Remove PROACTIVE_ANNOUNCEMENTS_CHANNEL_ID from config
+ExternalSources: []
+Summary: Move proactive channel ID from environment variable to MongoDB storage with Discord slash command for configuration
+LastUpdated: 2025-12-19T13:53:24.917442-08:00
+---
+
+# Proactive Channel Configuration via MongoDB and Discord Command
+
+## Executive Summary
+
+Currently, the proactive messaging channel ID is configured via the `PROACTIVE_ANNOUNCEMENTS_CHANNEL_ID` environment variable. This design proposes moving this configuration to MongoDB storage and adding a Discord slash command (`/set-proactive-channel`) to allow administrators to configure the channel directly from Discord without requiring environment variable changes or container restarts.
+
+This change improves operational flexibility, allows per-guild configuration (preparing for potential multi-guild support), and provides a more user-friendly configuration interface.
+
+## Problem Statement
+
+The current implementation stores the proactive announcements channel ID in an environment variable (`PROACTIVE_ANNOUNCEMENTS_CHANNEL_ID`). This approach has several limitations:
+
+1. **Operational overhead**: Changing the channel requires updating environment variables and restarting the container
+2. **No runtime configuration**: Cannot change the channel without downtime
+3. **No per-guild flexibility**: Environment variables are global, making multi-guild support difficult if needed in the future
+4. **Poor user experience**: Administrators must know about environment variables and have access to deployment configuration
+
+## Proposed Solution
+
+### Components
+
+1. **New MongoDB Model**: Create `GuildSettings` model to store guild-specific configuration
+   - Schema: `guildId` (unique), `proactiveAnnouncementsChannelId` (optional string)
+   - Single document per guild (upsert pattern)
+
+2. **Discord Slash Command**: `/set-proactive-channel`
+   - Required option: `channel` (Discord channel mention/ID)
+   - Action: Store channel ID in MongoDB for the current guild
+   - Response: Confirm channel set, show current channel if already configured
+
+3. **Update Weekly Announcement Job**: Modify `lib/proactive/jobs/weeklyAnnouncement.js`
+   - Read channel ID from MongoDB instead of `config.proactive.announcementsChannelId`
+   - Handle missing configuration gracefully (skip job with clear error message)
+
+### Architecture
+
+```
+Discord Command: /set-proactive-channel
+  └─> Updates GuildSettings collection
+        └─> Weekly announcement job reads from GuildSettings
+```
+
+## Design Decisions
+
+### 1. GuildSettings Model Design
+
+**Decision**: Single document per guild with flat structure
+- **Rationale**: Simple, easy to query, supports future expansion (other guild settings)
+- **Schema**:
+  ```javascript
+  {
+    guildId: String (required, unique, indexed),
+    proactiveAnnouncementsChannelId: String (optional),
+    updatedAt: Date (auto-updated),
+    updatedBy: String (Discord user ID who made the change)
+  }
+  ```
+
+### 2. Channel Validation
+
+**Decision**: Validate channel exists and bot has permission to send messages
+- **Rationale**: Prevents configuration errors, provides immediate feedback
+- **Implementation**: Use `client.channels.fetch()` and check `channel.permissionsFor(client.user)`
+
+### 3. Command Response Format
+
+**Decision**: Show current configuration and confirmation message
+- **Rationale**: Clear feedback, allows verification
+- **Format**: "✅ Proactive announcements channel set to #channel-name. Weekly announcements will be posted here."
+
+## Alternatives Considered
+
+### Alternative 1: Keep Environment Variable Only
+
+**Rejected because**: Doesn't solve operational overhead or runtime configuration needs
+
+### Alternative 2: Use Discord Application Commands with Channel Selection
+
+**Considered**: Use Discord's built-in channel option type
+**Decision**: Use this approach - Discord provides `ChannelType.GuildText` option type
+**Rationale**: Better UX, built-in validation, no need to parse channel mentions
+
+### Alternative 3: Separate Collection for Each Setting Type
+
+**Rejected because**: Over-engineered for current needs; single GuildSettings model is simpler and sufficient
+
+### Alternative 4: Store in Existing ScheduledSpeaker Model
+
+**Rejected because**: Violates single responsibility principle; settings are not speaker-specific
+
+## Implementation Plan
+
+### Phase 1: Create GuildSettings Model
+
+1. Create `models/guildSettings.js`
+   - Define schema with `guildId` (unique, indexed), `proactiveAnnouncementsChannelId`, `updatedAt`, `updatedBy`
+   - Export Mongoose model
+
+2. Add helper function `lib/proactive/getGuildSettings.js`
+   - Function: `getGuildSettings(guildId)` - returns settings document or null
+   - Function: `getProactiveChannelId(guildId)` - returns channel ID or null
+
+**Tests**: `test/models/guildSettings.test.js`
+- Create/update guild settings
+- Unique constraint on guildId
+- Query by guildId
+
+### Phase 2: Create Discord Command
+
+1. Create `lib/discord/commands/set-proactive-channel.js`
+   - Command definition: `/set-proactive-channel` with `channel` option (ChannelType.GuildText)
+   - Validation: Verify channel exists and bot can send messages
+   - Database update: Upsert GuildSettings document
+   - Response: Confirmation message with channel name
+
+2. Register command in `lib/discord/deploy-commands.js` (automatic via file discovery)
+
+**Tests**: `test/lib/discord/commands/set-proactive-channel.test.js`
+- Command validates channel
+- Command updates MongoDB
+- Command shows confirmation message
+- Command handles invalid channel gracefully
+
+### Phase 3: Update Weekly Announcement Job
+
+1. Update `lib/proactive/jobs/weeklyAnnouncement.js`
+   - Replace `config.proactive.announcementsChannelId` with MongoDB lookup
+   - Use `getProactiveChannelId(guildId)` helper
+   - Handle missing configuration gracefully (skip job with clear error message)
+
+2. Update job to accept `guildId` parameter (or read from config.discord.guildId)
+
+**Tests**: `test/lib/proactive/jobs/weeklyAnnouncement.test.js` (update existing)
+- Reads from MongoDB when configured
+- Handles missing configuration gracefully
+- Error messages indicate configuration is missing
+
+### Phase 4: Add Command to View Current Configuration
+
+1. Optional: Add `/get-proactive-channel` command
+   - Shows current channel configuration
+   - Shows "not configured" if not set
+
+**Tests**: `test/lib/discord/commands/get-proactive-channel.test.js`
+- Shows MongoDB configuration when set
+- Shows "not configured" when not set
+
+### Phase 5: Documentation
+
+1. Update `config/index.js`
+   - Remove `PROACTIVE_ANNOUNCEMENTS_CHANNEL_ID` from config
+
+2. Update documentation
+   - `README.md`: Document new command
+   - `AGENTS.md`: Update proactive messaging section with new command
+
+3. Update tests
+   - Ensure all existing tests still pass
+   - Add integration tests for full flow
+
+## Open Questions
+
+1. **Should we support multiple channels?** Currently single channel per guild. Future enhancement could support multiple announcement channels.
+
+2. **Should we add a command to disable proactive announcements?** Could set channel to null or add a separate `enabled` flag.
+
+3. **Should we log configuration changes?** The `updatedBy` field captures who made the change, but should we add audit logging?
+
+4. **Should we validate channel type?** Currently using `ChannelType.GuildText` - should we allow other channel types (announcement channels, forums)?
+
+## References
+
+- Related ticket: `ADD_PROACTIVE_MESSAGES` - Original proactive messaging implementation
+- Discord.js documentation: [Slash Commands](https://discord.js.org/#/docs/discord.js/main/class/SlashCommandBuilder)
+- Discord.js documentation: [Channel Types](https://discord.js.org/#/docs/discord.js/main/typedef/ChannelType)
+- Mongoose documentation: [Schemas](https://mongoosejs.com/docs/guide.html)

--- a/ttmp/2025/12/19/PROACTIVE_CHANNEL_CONFIG--store-proactive-channel-id-in-mongodb-with-discord-command/index.md
+++ b/ttmp/2025/12/19/PROACTIVE_CHANNEL_CONFIG--store-proactive-channel-id-in-mongodb-with-discord-command/index.md
@@ -1,0 +1,72 @@
+---
+Title: Store proactive channel ID in MongoDB with Discord command
+Ticket: PROACTIVE_CHANNEL_CONFIG
+Status: active
+Topics:
+    - discord
+    - bot
+    - proactive
+    - configuration
+DocType: index
+Intent: long-term
+Owners: []
+RelatedFiles:
+    - Path: models/guildSettings.js
+      Note: New model to store guild-specific configuration including proactive channel ID
+    - Path: lib/discord/commands/set-proactive-channel.js
+      Note: New Discord command to configure proactive announcements channel
+    - Path: lib/proactive/jobs/weeklyAnnouncement.js
+      Note: Update to read channel ID from MongoDB instead of config, with env var fallback
+    - Path: lib/proactive/getGuildSettings.js
+      Note: Helper functions to get guild settings and proactive channel ID with fallback
+    - Path: config/index.js
+      Note: Mark PROACTIVE_ANNOUNCEMENTS_CHANNEL_ID as deprecated (keep for backward compatibility)
+ExternalSources: []
+Summary: Move proactive channel ID from environment variable to MongoDB storage with Discord slash command for configuration
+LastUpdated: 2025-12-19T13:53:21.072662-08:00
+---
+
+# Store proactive channel ID in MongoDB with Discord command
+
+## Overview
+
+This ticket moves the proactive announcements channel ID from environment variable configuration to MongoDB storage, and adds a Discord slash command (`/set-proactive-channel`) to allow administrators to configure the channel directly from Discord.
+
+**Current State**: Channel ID is stored in `PROACTIVE_ANNOUNCEMENTS_CHANNEL_ID` environment variable, requiring container restarts to change.
+
+**Goal**: Store channel ID in MongoDB (`GuildSettings` model) and provide Discord command for runtime configuration without restarts.
+
+**Status**: Design phase - see [design document](./design-doc/01-proactive-channel-configuration-via-mongodb-and-discord-command.md) for implementation plan.
+
+## Key Links
+
+- **Related Files**: See frontmatter RelatedFiles field
+- **External Sources**: See frontmatter ExternalSources field
+
+## Status
+
+Current status: **active**
+
+## Topics
+
+- discord
+- bot
+- proactive
+- configuration
+
+## Tasks
+
+See [tasks.md](./tasks.md) for the current task list.
+
+## Changelog
+
+See [changelog.md](./changelog.md) for recent changes and decisions.
+
+## Structure
+
+- design/ - Architecture and design documents
+- reference/ - Prompt packs, API contracts, context summaries
+- playbooks/ - Command sequences and test procedures
+- scripts/ - Temporary code and tooling
+- various/ - Working notes and research
+- archive/ - Deprecated or reference-only artifacts

--- a/ttmp/2025/12/19/PROACTIVE_CHANNEL_CONFIG--store-proactive-channel-id-in-mongodb-with-discord-command/index.md
+++ b/ttmp/2025/12/19/PROACTIVE_CHANNEL_CONFIG--store-proactive-channel-id-in-mongodb-with-discord-command/index.md
@@ -1,7 +1,7 @@
 ---
 Title: Store proactive channel ID in MongoDB with Discord command
 Ticket: PROACTIVE_CHANNEL_CONFIG
-Status: active
+Status: complete
 Topics:
     - discord
     - bot
@@ -23,8 +23,9 @@ RelatedFiles:
       Note: Mark PROACTIVE_ANNOUNCEMENTS_CHANNEL_ID as deprecated (keep for backward compatibility)
 ExternalSources: []
 Summary: Move proactive channel ID from environment variable to MongoDB storage with Discord slash command for configuration
-LastUpdated: 2025-12-19T13:53:21.072662-08:00
+LastUpdated: 2025-12-19T14:09:03.839542-08:00
 ---
+
 
 # Store proactive channel ID in MongoDB with Discord command
 

--- a/ttmp/2025/12/19/PROACTIVE_CHANNEL_CONFIG--store-proactive-channel-id-in-mongodb-with-discord-command/reference/01-implementation-diary.md
+++ b/ttmp/2025/12/19/PROACTIVE_CHANNEL_CONFIG--store-proactive-channel-id-in-mongodb-with-discord-command/reference/01-implementation-diary.md
@@ -1,0 +1,220 @@
+---
+Title: Implementation Diary
+Ticket: PROACTIVE_CHANNEL_CONFIG
+Status: active
+Topics:
+    - discord
+    - bot
+    - proactive
+    - configuration
+DocType: reference
+Intent: long-term
+Owners: []
+RelatedFiles:
+    - Path: lib/discord/commands/set-proactive-channel.js
+      Note: |-
+        Discord slash command to configure proactive channel (commit eca63bc)
+        Discord slash command to configure proactive channel
+    - Path: lib/proactive/getGuildSettings.js
+      Note: |-
+        Helper functions to query guild settings (commit 42e6d40)
+        Helper functions to query guild settings
+    - Path: lib/proactive/jobs/weeklyAnnouncement.js
+      Note: |-
+        Updated to use MongoDB lookup with config fallback (commit 994836d)
+        Updated to use MongoDB lookup with config fallback
+    - Path: models/guildSettings.js
+      Note: |-
+        New MongoDB model for guild-specific settings (commit 42e6d40)
+        New MongoDB model for guild-specific settings
+ExternalSources: []
+Summary: Step-by-step implementation diary for moving proactive channel configuration from environment variables to MongoDB with Discord command
+LastUpdated: 2025-12-19T14:30:00-08:00
+---
+
+
+# Implementation Diary
+
+## Goal
+
+This diary documents the implementation of moving proactive announcements channel configuration from environment variables to MongoDB storage, with a Discord slash command (`/set-proactive-channel`) for runtime configuration.
+
+## Step 1: Create GuildSettings Model and Helper Functions
+
+This step establishes the MongoDB schema and query helpers for guild-specific settings. The model uses a simple flat structure with unique constraint on guildId, making it easy to query and expand in the future.
+
+**Commit (code):** 42e6d402e351d0503fc0641751e4658658d3f61a — "Phase 1: Create GuildSettings model and helper functions"
+
+### What I did
+- Created `models/guildSettings.js` with Mongoose schema (guildId, proactiveAnnouncementsChannelId, updatedAt, updatedBy)
+- Added unique index on guildId field
+- Created `lib/proactive/getGuildSettings.js` with `getGuildSettings()` and `getProactiveChannelId()` helper functions
+- Created comprehensive test suite `test/models/guildSettings.test.js` covering create/update, unique constraints, queries, and helper functions
+
+### Why
+- Need persistent storage for guild-specific configuration
+- Simple flat schema supports future expansion without over-engineering
+- Helper functions abstract MongoDB queries and provide clean API
+
+### What worked
+- All 20 tests pass, covering model operations, unique constraints, and helper function edge cases
+- Schema design allows easy upsert pattern for guild settings
+- Helper functions handle null/undefined guildId gracefully
+
+### What didn't work
+- Initial test run failed due to missing `deasync` native bindings - resolved with `npm rebuild deasync`
+
+### What I learned
+- Mongoose `pre('save')` hook can update timestamps automatically
+- Unique index on guildId prevents duplicate guild settings documents
+- Helper functions should handle null inputs gracefully for robustness
+
+### What was tricky to build
+- Ensuring unique constraint works correctly with upsert operations
+- Testing edge cases for null/undefined guildId inputs
+
+### What warrants a second pair of eyes
+- Schema design decision: flat structure vs nested - verify this meets future needs
+- Index strategy: single unique index on guildId is sufficient for current use case
+
+### What should be done in the future
+- Consider adding validation for channel ID format (Discord snowflake pattern)
+- Add migration script if we need to migrate existing env var configs to MongoDB
+- Consider adding audit logging for configuration changes
+
+### Code review instructions
+- Start with `models/guildSettings.js` - verify schema fields and indexes
+- Review `lib/proactive/getGuildSettings.js` - check error handling and null cases
+- Run `npm test -- test/models/guildSettings.test.js` to verify all tests pass
+
+### Technical details
+- Schema uses Mongoose with unique index: `guildId: { type: String, required: true, unique: true, index: true }`
+- Helper functions return null for missing records (not errors) for easier null checks
+- Tests use mongodb-memory-server for isolated test runs
+
+## Step 2: Create Discord Slash Command
+
+This step implements the `/set-proactive-channel` Discord command that allows administrators to configure the proactive announcements channel directly from Discord without requiring environment variable changes or container restarts.
+
+**Commit (code):** eca63bc3781229ec11d757255df564dbeae7192a — "Phase 2: Create set-proactive-channel Discord command with tests"
+
+### What I did
+- Created `lib/discord/commands/set-proactive-channel.js` with SlashCommandBuilder
+- Implemented channel validation (exists, bot has SendMessages permission)
+- Added MongoDB upsert logic using GuildSettings.findOneAndUpdate
+- Created comprehensive test suite `test/lib/discord/commands/set-proactive-channel.test.js` with mocked Discord interactions
+
+### Why
+- Provides user-friendly runtime configuration interface
+- Validates channel permissions before saving to prevent configuration errors
+- Uses Discord's built-in ChannelType.GuildText option for better UX
+
+### What worked
+- All 20 tests pass, covering successful saves, permission errors, channel not found, and update scenarios
+- Command automatically discovered by deploy-commands.js via file system scanning
+- Permission validation prevents invalid configurations
+
+### What didn't work
+- Initial test mocks didn't include `permissionsFor` method - fixed by adding proper mock structure
+- Channel mention formatting in tests needed adjustment (Discord.js formats channels differently than raw strings)
+
+### What I learned
+- Discord.js ChannelType.GuildText provides built-in channel selection UI
+- Permission checking requires fetching guild member and using channel.permissionsFor()
+- Mock Discord interactions need to match real Discord.js object structure closely
+
+### What was tricky to build
+- Properly mocking Discord.js interaction objects for testing
+- Handling permission checks when permissionsFor might not exist (for test mocks)
+- Ensuring error messages are user-friendly and actionable
+
+### What warrants a second pair of eyes
+- Permission validation logic - verify we're checking the right permissions
+- Error message clarity - ensure users understand what went wrong and how to fix it
+- Command response format - confirm ephemeral vs public reply is appropriate
+
+### What should be done in the future
+- Consider adding command to view current configuration (`/get-proactive-channel`)
+- Add role-based access control if needed (currently any user can run command)
+- Consider adding confirmation for channel changes (show old vs new channel)
+
+### Code review instructions
+- Start with `lib/discord/commands/set-proactive-channel.js` - verify validation and MongoDB operations
+- Review test mocks in `test/lib/discord/commands/set-proactive-channel.test.js` - ensure they match real Discord.js structure
+- Run `npm test -- test/lib/discord/commands/set-proactive-channel.test.js` to verify all tests pass
+
+### Technical details
+- Uses `ChannelType.GuildText` to restrict channel selection to text channels only
+- Permission check: `fetchedChannel.permissionsFor(botMember).has(PermissionFlagsBits.SendMessages)`
+- Upsert pattern: `GuildSettings.findOneAndUpdate({ guildId }, {...}, { upsert: true, new: true })`
+
+## Step 3: Update Weekly Announcement Job
+
+This step updates the weekly announcement job to read channel ID from MongoDB instead of environment variables, with fallback to config for backward compatibility during migration.
+
+**Commit (code):** 994836d270ddb1f26874094879802107b4d38cf3 — "Phase 3: Update weeklyAnnouncement job to use MongoDB with config fallback"
+
+### What I did
+- Updated `lib/proactive/jobs/weeklyAnnouncement.js` to import `getProactiveChannelId` helper
+- Replaced direct config access with MongoDB lookup: `getProactiveChannelId(guildId) || config.proactive.announcementsChannelId`
+- Updated error message to mention `/set-proactive-channel` command
+- Updated all existing tests to use MongoDB configuration
+- Added new tests for fallback behavior and missing configuration scenarios
+
+### Why
+- Enables runtime configuration without container restarts
+- Maintains backward compatibility with existing env var config during migration
+- Provides clear error messages directing users to the configuration command
+
+### What worked
+- All 21 tests pass, including existing tests updated for MongoDB and new fallback/missing config tests
+- Backward compatibility maintained - existing deployments with env vars continue working
+- Error messages clearly direct users to `/set-proactive-channel` command
+
+### What didn't work
+- Initial test updates had incorrect import paths (wrong number of `../` levels) - fixed by correcting relative paths
+- Had to update all three existing tests to set up MongoDB config instead of just setting config values
+
+### What I learned
+- Fallback pattern (`mongoValue || configValue`) provides smooth migration path
+- Test cleanup needs to restore both MongoDB state and config values
+- Error messages should be actionable (include command name, not just generic error)
+
+### What was tricky to build
+- Ensuring backward compatibility while transitioning to new storage mechanism
+- Updating all existing tests without breaking them
+- Proper test cleanup to avoid test pollution
+
+### What warrants a second pair of eyes
+- Fallback logic order - verify MongoDB-first, config-second is the right priority
+- Error message wording - ensure it's clear and helpful for administrators
+- Test coverage - verify all edge cases are covered (MongoDB set, config set, neither set, both set)
+
+### What should be done in the future
+- After migration period, remove config fallback and require MongoDB configuration
+- Update documentation to reflect new configuration method
+- Consider adding monitoring/alerting for missing channel configuration
+
+### Code review instructions
+- Start with `lib/proactive/jobs/weeklyAnnouncement.js` - verify MongoDB lookup and fallback logic
+- Review test updates in `test/lib/proactive/jobs/weeklyAnnouncement.test.js` - ensure all scenarios covered
+- Run `npm test -- test/lib/proactive/jobs/weeklyAnnouncement.test.js` to verify all 21 tests pass
+- Verify backward compatibility by checking that config.proactive.announcementsChannelId still works
+
+### Technical details
+- Channel ID resolution: `(await getProactiveChannelId(guildId)) || config.proactive.announcementsChannelId`
+- Error message: "Proactive announcements channel not configured. Use `/set-proactive-channel` to configure."
+- All tests now set up GuildSettings documents instead of just config values
+
+## Summary
+
+All three core phases are complete:
+1. ✅ MongoDB model and helpers (20 tests passing)
+2. ✅ Discord command implementation (20 tests passing)  
+3. ✅ Job update with backward compatibility (21 tests passing)
+
+Remaining optional work:
+- Phase 4: Optional `/get-proactive-channel` command
+- Phase 5: Documentation updates (README, AGENTS.md)
+
+The implementation maintains backward compatibility with existing environment variable configuration while enabling the new MongoDB-based runtime configuration via Discord command.

--- a/ttmp/2025/12/19/PROACTIVE_CHANNEL_CONFIG--store-proactive-channel-id-in-mongodb-with-discord-command/tasks.md
+++ b/ttmp/2025/12/19/PROACTIVE_CHANNEL_CONFIG--store-proactive-channel-id-in-mongodb-with-discord-command/tasks.md
@@ -1,0 +1,44 @@
+# Tasks
+
+## TODO
+
+### Phase 1: Create GuildSettings Model
+- [ ] Create `models/guildSettings.js` with schema (guildId, proactiveAnnouncementsChannelId, updatedAt, updatedBy)
+- [ ] Import mongoose and define GuildSettings schema with required fields
+- [ ] Export GuildSettings model from models/guildSettings.js
+- [ ] Implement getGuildSettings(guildId) function that queries MongoDB
+- [ ] Implement getProactiveChannelId(guildId) function that returns channel ID or null
+- [ ] Define SlashCommandBuilder with channel option (ChannelType.GuildText)
+- [ ] Use client.channels.fetch() to verify channel exists
+- [ ] Check channel.permissionsFor(client.user) to verify bot can send messages
+- [ ] Use GuildSettings.findOneAndUpdate() with upsert: true to save channel ID
+- [ ] Store updatedBy field with interaction.user.id
+- [ ] Replace config.proactive.announcementsChannelId with getProactiveChannelId(guildId) call
+- [ ] Read guildId from config.discord.guildId or pass as parameter to job
+- [ ] Return error message indicating channel not configured when getProactiveChannelId returns null
+- [ ] Add unique index on guildId
+- [ ] Create helper `lib/proactive/getGuildSettings.js` with `getGuildSettings()` and `getProactiveChannelId()` functions
+- [ ] Add tests `test/models/guildSettings.test.js` (create/update, unique constraint, queries)
+
+### Phase 2: Create Discord Command
+- [ ] Create `lib/discord/commands/set-proactive-channel.js` with channel option
+- [ ] Add channel validation (exists, bot can send messages)
+- [ ] Implement MongoDB upsert logic
+- [ ] Add confirmation response message
+- [ ] Add tests `test/lib/discord/commands/set-proactive-channel.test.js` (validation, DB update, error handling)
+
+### Phase 3: Update Weekly Announcement Job
+- [ ] Update `lib/proactive/jobs/weeklyAnnouncement.js` to use MongoDB lookup
+- [ ] Update error messages for missing configuration
+- [ ] Update existing tests to cover MongoDB lookup scenarios
+
+### Phase 4: Optional - View Command
+- [ ] Create `lib/discord/commands/get-proactive-channel.js` to show current configuration
+- [ ] Add tests for view command
+
+### Phase 5: Documentation
+- [ ] Update `config/index.js` to remove PROACTIVE_ANNOUNCEMENTS_CHANNEL_ID
+- [ ] Update `README.md` with new command documentation
+- [ ] Update `AGENTS.md` with proactive messaging command info
+- [ ] Verify all existing tests pass
+

--- a/ttmp/_guidelines/code-review.md
+++ b/ttmp/_guidelines/code-review.md
@@ -1,0 +1,18 @@
+# Guidelines: Code Review Documents
+
+## Purpose
+Capture the outcome of code reviews with enough context that future readers can understand scope, findings, and decisions.
+
+## Required Elements
+- **Summary**: One-paragraph overview of what was reviewed and the conclusion
+- **Context**: PRs, branches, features; links to tickets and references
+- **Files Reviewed**: Key files and rationale (consider notes in RelatedFiles)
+- **Findings**: Strengths and issues/risks
+- **Decisions & Follow-ups**: Decisions made and action items
+
+## Best Practices
+- Link to PRs, commits, and related docs
+- Keep findings concise; prefer bullet lists
+- Capture actionable follow-ups with owners
+- Use RelatedFiles with short notes to explain why files matter
+- Update when follow-ups are completed

--- a/ttmp/_guidelines/design-doc.md
+++ b/ttmp/_guidelines/design-doc.md
@@ -1,0 +1,20 @@
+# Guidelines: Design Documents
+
+## Purpose
+Design documents provide structured rationale and architecture notes. They document decisions, alternatives considered, and implementation plans.
+
+## Required Elements
+- **Executive Summary**: High-level overview
+- **Problem Statement**: Clear description of the problem
+- **Proposed Solution**: Detailed solution description
+- **Design Decisions**: Key decisions with rationale
+- **Alternatives Considered**: Other approaches evaluated
+- **Implementation Plan**: Steps to implement
+
+## Best Practices
+- Start with executive summary for quick scanning
+- Document the "why" behind decisions, not just the "what"
+- Include diagrams or code examples where helpful
+- Keep open questions visible until resolved
+- Link to related RFCs, tickets, or references
+- Use clear section hierarchy for easy navigation

--- a/ttmp/_guidelines/index.md
+++ b/ttmp/_guidelines/index.md
@@ -1,0 +1,20 @@
+# Guidelines: Index Documents
+
+## Purpose
+The index document is the canonical entry point for a ticket workspace. It provides a single source of truth for understanding the ticket's scope, status, and key resources.
+
+## Required Elements
+- **Overview**: Brief description of the ticket and its goals
+- **Status**: Current status of the ticket
+- **Key Links**: References to related files and external sources
+- **Topics**: The main topics this ticket addresses
+- **Tasks**: Link to tasks.md
+- **Changelog**: Link to changelog.md
+- **Structure**: Brief overview of the directory structure
+
+## Best Practices
+- Keep the overview concise but informative
+- Update status regularly as work progresses
+- Maintain RelatedFiles to help LLMs discover relevant code
+- Link to important decisions and documents
+- Use consistent formatting for easy scanning

--- a/ttmp/_guidelines/log.md
+++ b/ttmp/_guidelines/log.md
@@ -1,0 +1,16 @@
+# Guidelines: Log Documents
+
+## Purpose
+Logs maintain a running changelog, incident timeline, or decision log. They track what happened and when.
+
+## Required Elements
+- **Log Entries**: Chronological entries (newest first)
+
+## Best Practices
+- Use reverse chronological order (newest first)
+- Include dates in entry headers
+- Keep entries concise but informative
+- Document decisions and their rationale
+- Link to related commits or documents
+- Maintain consistent formatting
+- Update promptly after notable events

--- a/ttmp/_guidelines/playbook.md
+++ b/ttmp/_guidelines/playbook.md
@@ -1,0 +1,19 @@
+# Guidelines: Playbook Documents
+
+## Purpose
+Playbooks document command sequences, manual test procedures, or operational steps. They're designed for repeated execution.
+
+## Required Elements
+- **Purpose**: What the playbook accomplishes
+- **Environment Assumptions**: Required setup
+- **Commands**: The actual command sequence
+- **Exit Criteria**: Success indicators
+
+## Best Practices
+- List all prerequisites upfront
+- Use code blocks for commands
+- Include expected outputs
+- Document failure modes
+- Update when commands change
+- Keep environment assumptions explicit
+- Include timing estimates if relevant

--- a/ttmp/_guidelines/reference.md
+++ b/ttmp/_guidelines/reference.md
@@ -1,0 +1,18 @@
+# Guidelines: Reference Documents
+
+## Purpose
+Reference documents provide copy/paste-ready context, API contracts, prompt packs, or quick-look tables. They're designed for reuse in LLM prompts or as quick reference during development.
+
+## Required Elements
+- **Goal**: What this reference accomplishes
+- **Context**: Background needed to use the reference
+- **Quick Reference**: The actual reference content (code, tables, prompts)
+- **Usage Examples**: How to use this reference
+
+## Best Practices
+- Focus on copy/paste-ready content
+- Keep context minimal but sufficient
+- Format for easy scanning (tables, code blocks)
+- Include practical examples
+- Update when APIs or processes change
+- Link to related references or design docs

--- a/ttmp/_guidelines/script.md
+++ b/ttmp/_guidelines/script.md
@@ -1,0 +1,18 @@
+# Guidelines: Script Documents
+
+## Purpose
+Script documents describe temporary code, SQL snippets, or REPL transcripts. They live in the scripts/ directory alongside executable files.
+
+## Required Elements
+- **Purpose**: What the script does
+- **Usage**: How to run it
+- **Implementation**: Description or link to executable
+
+## Best Practices
+- Keep scripts focused on a single purpose
+- Document all required parameters
+- Include usage examples
+- Note any side effects or dependencies
+- Link to related design docs if applicable
+- Archive when no longer needed
+- Include a README.md in scripts/ summarizing all scripts

--- a/ttmp/_guidelines/task-list.md
+++ b/ttmp/_guidelines/task-list.md
@@ -1,0 +1,17 @@
+# Guidelines: Task List Documents
+
+## Purpose
+Task lists provide canonical TODO tracking with checkboxes and owners. They keep execution visible and machine-readable.
+
+## Required Elements
+- **Tasks**: List of uncompleted tasks with checkboxes
+- **Completed**: List of completed tasks
+- **Notes**: Additional context or blockers
+
+## Best Practices
+- Use Markdown checkboxes for machine readability
+- Assign owners to tasks when possible
+- Move completed items to completed section
+- Keep tasks specific and actionable
+- Update regularly as work progresses
+- Link to related documents or code

--- a/ttmp/_guidelines/tutorial.md
+++ b/ttmp/_guidelines/tutorial.md
@@ -1,0 +1,20 @@
+# Guidelines: Tutorial Documents
+
+## Purpose
+Tutorials provide step-by-step workflows or reusable prompt playbooks. They guide readers through a process from start to finish.
+
+## Required Elements
+- **Overview**: Learning objectives
+- **Prerequisites**: Required knowledge or setup
+- **Step-by-Step Guide**: Detailed walkthrough
+- **Verification**: How to verify completion
+- **Troubleshooting**: Common issues and solutions
+
+## Best Practices
+- Start with clear learning objectives
+- Break steps into logical chunks
+- Include code examples and expected outputs
+- Provide verification steps
+- Anticipate common pitfalls
+- Link to related resources
+- Follow glazed documentation style guidelines

--- a/ttmp/_guidelines/working-note.md
+++ b/ttmp/_guidelines/working-note.md
@@ -1,0 +1,18 @@
+# Guidelines: Working Notes
+
+## Purpose
+Working notes capture free-form logs, meeting summaries, research findings, or exploratory thoughts. They're ephemeral but help maintain context during active work.
+
+## Required Elements
+- **Summary**: Brief summary for LLM ingestion (at the top)
+- **Notes**: The main content (free-form)
+- **Decisions**: Any decisions made
+- **Next Steps**: Follow-up actions
+
+## Best Practices
+- Always include a summary at the top
+- Keep notes focused and organized
+- Extract important decisions to changelog.md
+- Mark resolved items clearly
+- Use consistent date formatting
+- Archive when ticket is complete

--- a/ttmp/_templates/code-review.md
+++ b/ttmp/_templates/code-review.md
@@ -1,0 +1,44 @@
+---
+Title: {{TITLE}}
+Ticket: {{TICKET}}
+Status: draft
+Topics:
+{{TOPICS}}
+DocType: code-review
+Intent: long-term
+Owners:
+{{OWNERS}}
+RelatedFiles: []
+ExternalSources: []
+Summary: >
+  {{SUMMARY}}
+LastUpdated: {{DATE}}
+---
+
+# {{TITLE}}
+
+## Summary
+
+<!-- One-paragraph summary of the review scope and outcome -->
+
+## Context
+
+<!-- PRs, branches, or features reviewed; link to tickets and references -->
+
+## Files Reviewed
+
+<!-- Bullet list of key files; add rationale in RelatedFiles notes when possible -->
+
+## Findings
+
+- Strengths:
+- Issues / Risks:
+
+## Decisions & Follow-ups
+
+- Decisions:
+- Action Items:
+
+## References
+
+<!-- Links to PRs, commits, docs, or external resources -->

--- a/ttmp/_templates/design-doc.md
+++ b/ttmp/_templates/design-doc.md
@@ -1,0 +1,50 @@
+---
+Title: {{TITLE}}
+Ticket: {{TICKET}}
+Status: draft
+Topics:
+{{TOPICS}}
+DocType: design-doc
+Intent: long-term
+Owners:
+{{OWNERS}}
+RelatedFiles: []
+ExternalSources: []
+Summary: >
+  {{SUMMARY}}
+LastUpdated: {{DATE}}
+---
+
+# {{TITLE}}
+
+## Executive Summary
+
+<!-- Provide a high-level overview of the design proposal -->
+
+## Problem Statement
+
+<!-- Describe the problem this design addresses -->
+
+## Proposed Solution
+
+<!-- Describe the proposed solution in detail -->
+
+## Design Decisions
+
+<!-- Document key design decisions and rationale -->
+
+## Alternatives Considered
+
+<!-- List alternative approaches that were considered and why they were rejected -->
+
+## Implementation Plan
+
+<!-- Outline the steps to implement this design -->
+
+## Open Questions
+
+<!-- List any unresolved questions or concerns -->
+
+## References
+
+<!-- Link to related documents, RFCs, or external resources -->

--- a/ttmp/_templates/index.md
+++ b/ttmp/_templates/index.md
@@ -1,0 +1,52 @@
+---
+Title: {{TITLE}}
+Ticket: {{TICKET}}
+Status: draft
+Topics:
+{{TOPICS}}
+DocType: index
+Intent: short-term
+Owners:
+{{OWNERS}}
+RelatedFiles: []
+ExternalSources: []
+Summary: >
+  {{SUMMARY}}
+LastUpdated: {{DATE}}
+---
+
+# {{TITLE}}
+
+## Overview
+
+<!-- Provide a brief overview of the ticket, its goals, and current status -->
+
+## Key Links
+
+- **Related Files**: See frontmatter RelatedFiles field
+- **External Sources**: See frontmatter ExternalSources field
+
+## Status
+
+Current status: **{{STATUS}}**
+
+## Topics
+
+{{TOPICS_LIST}}
+
+## Tasks
+
+See [tasks.md](./tasks.md) for the current task list.
+
+## Changelog
+
+See [changelog.md](./changelog.md) for recent changes and decisions.
+
+## Structure
+
+- design/ - Architecture and design documents
+- reference/ - Prompt packs, API contracts, context summaries
+- playbooks/ - Command sequences and test procedures
+- scripts/ - Temporary code and tooling
+- various/ - Working notes and research
+- archive/ - Deprecated or reference-only artifacts

--- a/ttmp/_templates/log.md
+++ b/ttmp/_templates/log.md
@@ -1,0 +1,28 @@
+---
+Title: {{TITLE}}
+Ticket: {{TICKET}}
+Status: draft
+Topics:
+{{TOPICS}}
+DocType: log
+Intent: short-term
+Owners:
+{{OWNERS}}
+RelatedFiles: []
+ExternalSources: []
+Summary: >
+  {{SUMMARY}}
+LastUpdated: {{DATE}}
+---
+
+# {{TITLE}}
+
+<!-- Log entries in reverse chronological order (newest first) -->
+
+## {{DATE}} - Entry Title
+
+<!-- Log entry content -->
+
+## {{DATE}} - Entry Title
+
+<!-- Previous log entry -->

--- a/ttmp/_templates/playbook.md
+++ b/ttmp/_templates/playbook.md
@@ -1,0 +1,42 @@
+---
+Title: {{TITLE}}
+Ticket: {{TICKET}}
+Status: draft
+Topics:
+{{TOPICS}}
+DocType: playbook
+Intent: short-term
+Owners:
+{{OWNERS}}
+RelatedFiles: []
+ExternalSources: []
+Summary: >
+  {{SUMMARY}}
+LastUpdated: {{DATE}}
+---
+
+# {{TITLE}}
+
+## Purpose
+
+<!-- What does this playbook accomplish? -->
+
+## Environment Assumptions
+
+<!-- What environment or setup is required? -->
+
+## Commands
+
+<!-- List of commands to execute -->
+
+```bash
+# Command sequence
+```
+
+## Exit Criteria
+
+<!-- What indicates success or completion? -->
+
+## Notes
+
+<!-- Additional context or warnings -->

--- a/ttmp/_templates/reference.md
+++ b/ttmp/_templates/reference.md
@@ -1,0 +1,38 @@
+---
+Title: {{TITLE}}
+Ticket: {{TICKET}}
+Status: draft
+Topics:
+{{TOPICS}}
+DocType: reference
+Intent: long-term
+Owners:
+{{OWNERS}}
+RelatedFiles: []
+ExternalSources: []
+Summary: >
+  {{SUMMARY}}
+LastUpdated: {{DATE}}
+---
+
+# {{TITLE}}
+
+## Goal
+
+<!-- What is the purpose of this reference document? -->
+
+## Context
+
+<!-- Provide background context needed to use this reference -->
+
+## Quick Reference
+
+<!-- Provide copy/paste-ready content, API contracts, or quick-look tables -->
+
+## Usage Examples
+
+<!-- Show how to use this reference in practice -->
+
+## Related
+
+<!-- Link to related documents or resources -->

--- a/ttmp/_templates/script.md
+++ b/ttmp/_templates/script.md
@@ -1,0 +1,36 @@
+---
+Title: {{TITLE}}
+Ticket: {{TICKET}}
+Status: draft
+Topics:
+{{TOPICS}}
+DocType: script
+Intent: throwaway
+Owners:
+{{OWNERS}}
+RelatedFiles: []
+ExternalSources: []
+Summary: >
+  {{SUMMARY}}
+LastUpdated: {{DATE}}
+---
+
+# {{TITLE}}
+
+## Purpose
+
+<!-- What does this script do? -->
+
+## Usage
+
+```bash
+# Usage example
+```
+
+## Implementation
+
+<!-- Describe the script implementation or link to executable file -->
+
+## Notes
+
+<!-- Additional context or warnings -->

--- a/ttmp/_templates/task-list.md
+++ b/ttmp/_templates/task-list.md
@@ -1,0 +1,32 @@
+---
+Title: {{TITLE}}
+Ticket: {{TICKET}}
+Status: draft
+Topics:
+{{TOPICS}}
+DocType: task-list
+Intent: short-term
+Owners:
+{{OWNERS}}
+RelatedFiles: []
+ExternalSources: []
+Summary: >
+  {{SUMMARY}}
+LastUpdated: {{DATE}}
+---
+
+# {{TITLE}}
+
+## Tasks
+
+- [ ] Task 1
+- [ ] Task 2
+- [ ] Task 3
+
+## Completed
+
+- [x] Example completed task
+
+## Notes
+
+<!-- Additional context or blockers -->

--- a/ttmp/_templates/tutorial.md
+++ b/ttmp/_templates/tutorial.md
@@ -1,0 +1,48 @@
+---
+Title: {{TITLE}}
+Ticket: {{TICKET}}
+Status: draft
+Topics:
+{{TOPICS}}
+DocType: tutorial
+Intent: long-term
+Owners:
+{{OWNERS}}
+RelatedFiles: []
+ExternalSources: []
+Summary: >
+  {{SUMMARY}}
+LastUpdated: {{DATE}}
+---
+
+# {{TITLE}}
+
+## Overview
+
+<!-- What will readers learn in this tutorial? -->
+
+## Prerequisites
+
+<!-- What knowledge or setup is required? -->
+
+## Step-by-Step Guide
+
+### Step 1: Setup
+
+<!-- First step -->
+
+### Step 2: Implementation
+
+<!-- Next steps -->
+
+## Verification
+
+<!-- How to verify the tutorial was completed successfully -->
+
+## Troubleshooting
+
+<!-- Common issues and solutions -->
+
+## Related Resources
+
+<!-- Links to related documentation or examples -->

--- a/ttmp/_templates/working-note.md
+++ b/ttmp/_templates/working-note.md
@@ -1,0 +1,34 @@
+---
+Title: {{TITLE}}
+Ticket: {{TICKET}}
+Status: draft
+Topics:
+{{TOPICS}}
+DocType: working-note
+Intent: short-term
+Owners:
+{{OWNERS}}
+RelatedFiles: []
+ExternalSources: []
+Summary: >
+  {{SUMMARY}}
+LastUpdated: {{DATE}}
+---
+
+# {{TITLE}}
+
+## Summary
+
+<!-- Brief summary for LLM ingestion -->
+
+## Notes
+
+<!-- Free-form notes, meeting summaries, or research findings -->
+
+## Decisions
+
+<!-- Any decisions made during this working session -->
+
+## Next Steps
+
+<!-- Actions or follow-ups -->

--- a/ttmp/vocabulary.yaml
+++ b/ttmp/vocabulary.yaml
@@ -1,0 +1,34 @@
+topics:
+    - slug: chat
+      description: Chat backend and frontend surfaces
+    - slug: backend
+      description: Backend services
+    - slug: websocket
+      description: WebSocket lifecycle & events
+docTypes:
+    - slug: design-doc
+      description: Structured rationale and architecture notes
+    - slug: reference
+      description: Reference docs and API contracts
+    - slug: playbook
+      description: Operational procedures and QA/Smoke steps
+    - slug: index
+      description: Ticket landing page
+intent:
+    - slug: long-term
+      description: Likely to persist
+    - slug: short-term
+      description: Short-term documentation for active work
+    - slug: throwaway
+      description: Temporary/experimental documentation
+status:
+    - slug: draft
+      description: Initial draft state
+    - slug: active
+      description: Active work in progress
+    - slug: review
+      description: Ready for review
+    - slug: complete
+      description: Work completed
+    - slug: archived
+      description: Archived/completed work


### PR DESCRIPTION
This PR adds proactive messaging capabilities to the AI in Action Discord bot, enabling automated speaker reminders and weekly schedule announcements. The implementation uses Docker cron (dcron) to trigger internal HTTP endpoints (/internal/proactive/*) secured by loopback-only middleware. Two jobs were implemented: talk reminders that send DMs to speakers at T-1 day and day-of (with thread fallback if DMs fail), and weekly announcements that post the upcoming schedule to a configured channel. The ScheduledSpeaker schema was extended with reminder timestamp fields to ensure idempotency, preventing duplicate sends. Comprehensive test coverage was added for the security middleware, internal endpoints, and job logic.

A new /set-proactive-channel Discord slash command allows administrators to configure the announcements channel without container restarts, with validation that the bot has SendMessages permission in the target channel. The GuildSettings MongoDB model stores guild-specific settings with proper unique constraints. 

The PR also utilized a new under-development tool (docmgr) to manage internal documentation and show the historical thinking and context. This includes structured documents in a ttmp directory. If you would prefer we not include those in this project, let me know and I can strip them out.

In the meantime, they provide a useful window into the thinking and plans behind the implementation.